### PR TITLE
BMP file output corrections

### DIFF
--- a/src/Mike42/GfxPhp/Codec/BmpCodec.php
+++ b/src/Mike42/GfxPhp/Codec/BmpCodec.php
@@ -17,13 +17,14 @@ class BmpCodec implements ImageEncoder
         }
         // Output uncompressed 24 bit BMP file
         $header = pack(
-            "C2V3",
+            "C2Vv2V",
             0x42,
             0x4d, // 'BM' magic number
             0, // File size
             0, // Reserved
-            0
-        ); // Offset
+            0, // Reserved
+            54 // Offset
+        );
         $width = $image -> getWidth();
         $height = $image -> getHeight();
         $infoHeader = pack(
@@ -58,6 +59,7 @@ class BmpCodec implements ImageEncoder
 
     protected function transformRevString(&$item, $key)
     {
+        // Convert RGB to BGR
         $item = strrev($item);
     }
     

--- a/src/Mike42/GfxPhp/Codec/BmpCodec.php
+++ b/src/Mike42/GfxPhp/Codec/BmpCodec.php
@@ -8,6 +8,8 @@ use Mike42\GfxPhp\RgbRasterImage;
 class BmpCodec implements ImageEncoder
 {
     protected static $instance = null;
+    const INFO_HEADER_SIZE = 40;
+    const FILE_HEADER_SIZE = 14;
 
     public function encode(RasterImage $image, string $format): string
     {
@@ -15,21 +17,11 @@ class BmpCodec implements ImageEncoder
             // Convert if necessary
             $image = $image -> toRgb();
         }
-        // Output uncompressed 24 bit BMP file
-        $header = pack(
-            "C2Vv2V",
-            0x42,
-            0x4d, // 'BM' magic number
-            0, // File size
-            0, // Reserved
-            0, // Reserved
-            54 // Offset
-        );
         $width = $image -> getWidth();
         $height = $image -> getHeight();
         $infoHeader = pack(
             "V3v2V6",
-            40,
+            self::INFO_HEADER_SIZE,
             $width, // Width
             $height, // Height
             1, // Planes
@@ -39,8 +31,8 @@ class BmpCodec implements ImageEncoder
             1, // Horizontal res
             1, // Vertical res
             0, // Number of colors
-            0
-        ); // Number of important colors
+            0 // Number of important colors
+        );
         $colorTable = "";
         // Transform RGB ordering to BGR ordering
         $pixels = str_split($image -> getRasterData(), 3);
@@ -52,8 +44,19 @@ class BmpCodec implements ImageEncoder
         $padding = str_repeat("\x00", $paddingLength);
         $lines = str_split($rasterData, $originalWidth);
         $lines = array_reverse($lines, false);
+        // Uncompressed 24 bit BMP file
         $pixelData = implode($padding, $lines) . $padding;
         // Return bitmap & header
+        $fileSize = strlen($pixelData) + strlen($colorTable) + self::INFO_HEADER_SIZE + self::FILE_HEADER_SIZE;
+        $header = pack(
+            "C2Vv2V",
+            0x42, // 'BM' magic number
+            0x4d,
+            $fileSize, // file size
+            0, // Reserved
+            0, // Reserved
+            self::INFO_HEADER_SIZE + self::FILE_HEADER_SIZE // Offset
+            );
         return $header . $infoHeader . $colorTable . $pixelData;
     }
 


### PR DESCRIPTION
This change updates the BMP writer to include additional values in the output:

- File size
- Image data offset

These had previously been set to 0, which caused some BMP decoders to throw warnings or produce incorrect output.

Ref:

- #30