### PR TITLE
Add HHVM to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - hhvm-3.21
+  - hhvm-3.27
   - nightly
   - hhvm-nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - composer install
 
 before_script:
+  - bash -c 'if [[ $TRAVIS_PHP_VERSION == hhvm* ]]; then echo "hhvm.php7.all = 1" | sudo tee -a /etc/hhvm/php.ini; fi'
   - mkdir -p build/logs/
 
 script:

--- a/src/Mike42/GfxPhp/Image.php
+++ b/src/Mike42/GfxPhp/Image.php
@@ -17,11 +17,10 @@ class Image
     public static function fromFile(string $filename) : RasterImage
     {
         // Attempt to catch the cause of any errors
-        error_clear_last();
+        self::clearLastError();
         $blob = @file_get_contents($filename);
         if ($blob === false) {
-            $e = error_get_last();
-            $error = (isset($e) && isset($e['message']) && $e['message'] != "") ? $e['message'] : "Check that the file exists and can be read.";
+            $error = self::getLastErrorOrDefault("Check that the file exists and can be read.");
             throw new \Exception("Could not retrieve image data from '$filename'. $error");
         }
         return self::fromBlob($blob, $filename);
@@ -46,5 +45,30 @@ class Image
     public static function create(int $width, int $height, int $impl = self::IMAGE_BLACK_WHITE)
     {
         return BlackAndWhiteRasterImage::create($width, $height);
+    }
+
+    /**
+     * Call error_clear_last() if it exists. This is dependent on which PHP runtime is used.
+     */
+    private static function clearLastError()
+    {
+        if (function_exists('error_clear_last')) {
+            error_clear_last();
+        }
+    }
+
+    /**
+     * Retrieve the message from error_get_last() if possible. This is very useful for debugging, but it will not
+     * always exist or return anything useful.
+     */
+    private static function getLastErrorOrDefault(string $default)
+    {
+        if (function_exists('error_clear_last')) {
+            $e = error_get_last();
+            if (isset($e) && isset($e['message']) && $e['message'] != "") {
+                return $e['message'];
+            }
+        }
+        return $default;
     }
 }


### PR DESCRIPTION
Had to wrap `error_get_last()` and `error_clear_last()` for compatibility with HHVM, which apparently does not have these.

Some minor CI changes to lock in the new compatibility.

Ref:

- #36 