### PR TITLE
Additional BMP formats

### DIFF
--- a/docs/user/formats.rst
+++ b/docs/user/formats.rst
@@ -50,7 +50,7 @@ The GIF codec is used where the input has the ``gif`` file extension. Any well-f
 
 A GIF image will always be loaded into an instance of :class:`IndexedRasterImage`, which makes palette information available.
 
-PNG
+BMP
 ^^^
 
 The BMP codec is used where the input has the ``bmp`` or ``dib`` file extensions.

--- a/docs/user/formats.rst
+++ b/docs/user/formats.rst
@@ -53,10 +53,11 @@ A GIF image will always be loaded into an instance of :class:`IndexedRasterImage
 BMP
 ^^^
 
-The BMP codec is used where the input has the ``bmp`` or ``dib`` file extensions.
+The BMP codec is used where the input has the ``bmp`` or ``dib`` file extensions. Most uncompressed bitmap files cn be read.
 
-Only uncompressed 24-bit color bitmap images may currently be read. The returned object will be an
-instance of instance of :class:`RgbRasterImage`.
+The returned object will be an instance of instance of :class:`IndexedRasterImage` if the color depth is 8 or lower.
+
+24-bit bitmap images are loaded into an instance of :class:`RgbRasterImage`. 16-bit and 32-bit bitmaps are not supported.
 
 Netpbm Formats
 ^^^^^^^^^^^^^^

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
@@ -32,6 +32,7 @@ class BmpFile
         $infoHeader = BmpInfoHeader::fromBinary($data);
         if ($infoHeader -> bpp != 0 &&
             $infoHeader -> bpp != 1 &&
+            $infoHeader -> bpp != 2 &&
             $infoHeader -> bpp != 4 &&
             $infoHeader -> bpp != 8 &&
             $infoHeader -> bpp != 16 &&
@@ -109,8 +110,11 @@ class BmpFile
     public function toRasterImage() : RasterImage
     {
         if ($this -> infoHeader -> bpp == 1) {
-            $expandedData = PngImage::expandBytes1Bpp($this->uncompressedData, $this->infoHeader->width);
-            return IndexedRasterImage::create($this->infoHeader->width, $this->infoHeader->height, $expandedData, $this->palette);
+            $expandedData = PngImage::expandBytes1Bpp($this -> uncompressedData, $this -> infoHeader -> width);
+            return IndexedRasterImage::create($this -> infoHeader -> width, $this -> infoHeader -> height, $expandedData, $this -> palette);
+        } else if ($this -> infoHeader -> bpp == 2) {
+            $expandedData = PngImage::expandBytes2Bpp($this -> uncompressedData, $this -> infoHeader -> width);
+            return IndexedRasterImage::create($this->infoHeader -> width, $this -> infoHeader -> height, $expandedData, $this -> palette);
         } else if ($this -> infoHeader -> bpp == 4) {
             $expandedData = PngImage::expandBytes4Bpp($this -> uncompressedData, $this -> infoHeader -> width);
             return IndexedRasterImage::create($this -> infoHeader -> width, $this -> infoHeader -> height, $expandedData, $this -> palette);

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
@@ -3,6 +3,8 @@ namespace Mike42\GfxPhp\Codec\Bmp;
 
 use Exception;
 use Mike42\GfxPhp\Codec\Common\DataInputStream;
+use Mike42\GfxPhp\Codec\Png\PngImage;
+use Mike42\GfxPhp\IndexedRasterImage;
 use Mike42\GfxPhp\RasterImage;
 use Mike42\GfxPhp\RgbRasterImage;
 
@@ -12,13 +14,15 @@ class BmpFile
 
     private $fileHeader;
     private $infoHeader;
+    private $palette;
     private $uncompressedData;
 
-    public function __construct(BmpFileHeader $fileHeader, BmpInfoHeader $infoHeader, array $data)
+    public function __construct(BmpFileHeader $fileHeader, BmpInfoHeader $infoHeader, array $data, array $palette)
     {
         $this -> fileHeader = $fileHeader;
         $this -> infoHeader = $infoHeader;
         $this -> uncompressedData = $data;
+        $this -> palette = $palette;
     }
 
     public static function fromBinary(DataInputStream $data) : BmpFile
@@ -34,16 +38,25 @@ class BmpFile
             $infoHeader -> bpp != 24 &&
             $infoHeader -> bpp != 32) {
             throw new Exception("Bit depth " . $infoHeader -> bpp . " not valid.");
-        } else if ($infoHeader -> bpp != 24) {
+        } else if ($infoHeader -> bpp === 0 ||
+            $infoHeader -> bpp === 16 ||
+            $infoHeader -> bpp === 32) {
             // Fail early to give a clearer error for the things which aren't tested yet
             throw new Exception("Bit depth " . $infoHeader -> bpp . " not implemented.");
         }
-        // Skip color table (allowed in a true color image, but not useful)
+        // See how many colors we expect. 2^n colors in table for bpp <= 8, 0 for higher color depths
+        $colorCount = $infoHeader -> bpp <= 8 ? 2 **  $infoHeader -> bpp : 0;
         if ($infoHeader -> colors > 0) {
-            // for non-truecolor images, 0 will mean 2^bpp.
-            // Size of each entry may also be variable
-            $data -> read($infoHeader -> colors * 4);
+            // .. unless otherwise specified
+            $colorCount = $infoHeader -> colors;
         }
+        $colorTable = [];
+        for ($i = 0; $i < $colorCount; $i++) {
+            $entryData = $data -> read(4);
+            $color = unpack("C*", $entryData);
+            $colorTable[] = [$color[3], $color[2], $color[1]];
+        }
+        // May need to skip here if header shows pixel data later than we expect
         // Determine compressed & uncompressed size
         $rowSizeBytes = intdiv(($infoHeader -> bpp * $infoHeader -> width + 31), 32) * 4;
         $uncompressedImgSizeBytes = $rowSizeBytes * $infoHeader -> height;
@@ -86,13 +99,24 @@ class BmpFile
             $uncompressedImgData = implode("", $pixels);
         }
         // Convert to array of numbers 0-255.
-        $dataArray = array_values(unpack("c*", $uncompressedImgData));
-        return new BmpFile($fileHeader, $infoHeader, $dataArray);
+        $dataArray = array_values(unpack("C*", $uncompressedImgData));
+        if (!$data -> isEof()) {
+            throw new Exception("BMP image has unexpected trailing data");
+        }
+        return new BmpFile($fileHeader, $infoHeader, $dataArray, $colorTable);
     }
 
     public function toRasterImage() : RasterImage
     {
-        if ($this -> infoHeader -> bpp == 24) {
+        if ($this -> infoHeader -> bpp == 1) {
+            $expandedData = PngImage::expandBytes1Bpp($this->uncompressedData, $this->infoHeader->width);
+            return IndexedRasterImage::create($this->infoHeader->width, $this->infoHeader->height, $expandedData, $this->palette);
+        } else if ($this -> infoHeader -> bpp == 4) {
+            $expandedData = PngImage::expandBytes4Bpp($this -> uncompressedData, $this -> infoHeader -> width);
+            return IndexedRasterImage::create($this -> infoHeader -> width, $this -> infoHeader -> height, $expandedData, $this -> palette);
+        } else if ($this -> infoHeader -> bpp == 8) {
+            return IndexedRasterImage::create($this -> infoHeader -> width, $this -> infoHeader -> height, $this -> uncompressedData, $this -> palette);
+        } else if ($this -> infoHeader -> bpp == 24) {
             return RgbRasterImage::create($this -> infoHeader -> width, $this -> infoHeader -> height, $this -> uncompressedData);
         }
         throw new Exception("Unknown bit depth " . $this -> infoHeader -> bpp);

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
@@ -27,7 +27,7 @@ class BmpInfoHeader
     public $compression;
     public $headerSize;
     public $height;
-    public $hprizontalRes;
+    public $horizontalRes;
     public $importantColors;
     public $planes;
     public $verticalRes;
@@ -42,7 +42,7 @@ class BmpInfoHeader
         $this -> bpp = $bpp;
         $this -> compression = $compression;
         $this -> compressedSize = $compressedSize;
-        $this -> hprizontalRes = $horizontalRes;
+        $this -> horizontalRes = $horizontalRes;
         $this -> verticalRes = $verticalRes;
         $this -> colors = $colors;
         $this -> importantColors = $importantColors;

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -17,23 +17,27 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_badbitssize() {
-        $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badbitssize.bmp");
+        $this -> assertEquals(127, $img -> getWidth());
+        $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_baddens1() {
-        $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/baddens1.bmp");
+        $this -> assertEquals(127, $img -> getWidth());
+        $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_baddens2() {
-        $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/baddens2.bmp");
+        $this -> assertEquals(127, $img -> getWidth());
+        $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_badfilesize() {
-        $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badfilesize.bmp");
+        $this -> assertEquals(127, $img -> getWidth());
+        $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_badheadersize() {
@@ -47,8 +51,9 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_badplanes() {
-        $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badplanes.bmp");
+        $this -> assertEquals(127, $img -> getWidth());
+        $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_badrle() {
@@ -112,35 +117,30 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_pal1() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal1.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal1bg() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal1bg.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal1wb() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal1wb.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal4() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal4.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal4gs() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal4gs.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -154,28 +154,24 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_pal8_0() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8-0.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal8() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal8gs() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8gs.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal8nonsquare() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8nonsquare.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(32, $img -> getHeight());
@@ -217,21 +213,18 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_pal8w124() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8w124.bmp");
         $this -> assertEquals(124, $img -> getWidth());
         $this -> assertEquals(61, $img -> getHeight());
     }
 
     function test_pal8w125() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8w125.bmp");
         $this -> assertEquals(125, $img -> getWidth());
         $this -> assertEquals(62, $img -> getHeight());
     }
 
     function test_pal8w126() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8w126.bmp");
         $this -> assertEquals(126, $img -> getWidth());
         $this -> assertEquals(63, $img -> getHeight());
@@ -306,7 +299,6 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_pal1p1() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal1p1.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -376,7 +368,6 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_pal8os2v2_40sz() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2v2-40sz.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -397,7 +388,6 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_pal8oversizepal() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8oversizepal.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -305,14 +305,12 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_pal2() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal2.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal2color() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal2color.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());


### PR DESCRIPTION
Implement indexed 1, 2, 4, 8-bit bitmap images in uncompressed variant.

Ref:

- #43 