### PR TITLE
Implement RLE8 decode for BMP files

### DIFF
--- a/docs/user/formats.rst
+++ b/docs/user/formats.rst
@@ -53,7 +53,7 @@ A GIF image will always be loaded into an instance of :class:`IndexedRasterImage
 BMP
 ^^^
 
-The BMP codec is used where the input has the ``bmp`` or ``dib`` file extensions. Most uncompressed bitmap files cn be read.
+The BMP codec is used where the input has the ``bmp`` or ``dib`` file extensions. Most uncompressed or run-length encoded bitmap files can be read by this library.
 
 The returned object will be an instance of instance of :class:`IndexedRasterImage` if the color depth is 8 or lower.
 

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
@@ -65,6 +65,10 @@ class BmpFile
             $compressedImgSizeBytes = $uncompressedImgSizeBytes;
         } else {
             $compressedImgSizeBytes = $infoHeader -> compressedSize;
+            // Limit height to prevent insane allocations during decompression if file is corrupt
+            if ($infoHeader -> width > 65535 || $infoHeader -> height > 65535 || $infoHeader -> width < 0 || $infoHeader -> height < 0) {
+                throw new Exception("Image size " . $infoHeader -> width . "x" . $infoHeader -> height . " is outside the supported range.");
+            }
         }
         $compressedImgData = $data -> read($compressedImgSizeBytes);
         // De-compress if necessary
@@ -73,6 +77,15 @@ class BmpFile
                 $uncompressedImgData = $compressedImgData;
                 break;
             case BmpInfoHeader::B1_RLE8:
+                if ($infoHeader -> bpp !== 8) {
+                    throw new Exception("RLE8 compression only valid for 8-bit images");
+                }
+                $uncompressedImgData = self::rle8decode($compressedImgData, $infoHeader -> width, $infoHeader -> height);
+                $actualSize = strlen($uncompressedImgData);
+                if ($uncompressedImgSizeBytes !== $actualSize) {
+                    throw new Exception("RLE8 decode failed. Expected $uncompressedImgSizeBytes bytes uncompressed, got $actualSize");
+                }
+                break;
             case BmpInfoHeader::B1_RLE4:
             case BmpInfoHeader::B1_BITFILEDS:
             case BmpInfoHeader::B1_JPEG:
@@ -105,6 +118,115 @@ class BmpFile
             throw new Exception("BMP image has unexpected trailing data");
         }
         return new BmpFile($fileHeader, $infoHeader, $dataArray, $colorTable);
+    }
+
+    private static function rle8decode(string $compressedImgData, int $width, int $height)
+    {
+        // Padding to 4-byte boundary: Can this be simplified?
+        $rowWidth = intdiv((8 * $width + 31), 32) * 4;
+        // Initialize buffer to 0's
+        $outpNum = [];
+        for ($y = 0; $y < $height; $y++) {
+            $outpNum[] = array_fill(0, $rowWidth, 0);
+        }
+        // read input data into 2d buffer
+        $inpNum = array_values(unpack("C*", $compressedImgData));
+        $x = 0;
+        $y = 0;
+        $i = 0;
+        $len = intdiv(count($inpNum), 2) * 2;
+        while ($i < $len) {
+            $firstByte = $inpNum[$i];
+            $secondByte = $inpNum[$i + 1];
+            $i += 2;
+            //echo "Pair $firstByte $secondByte\n";
+            if ($firstByte === 0) {
+                if ($secondByte == 0) {
+                    //echo "End of line\n";
+                    // EOL
+                    $x = 0;
+                    $y++;
+                    if ($y >= $height) {
+                        //echo "ERROR Y overflow on EOL, breaking.";
+                        break;
+                    }
+                } else if ($secondByte == 1) {
+                    //echo "End of bitmap\n";
+                    // End of bitmap
+                    break;
+                } else if ($secondByte == 2) {
+                    if ($i >= $len) {
+                        throw new Exception("Unexpected EOF");
+                    }
+                    $firstDeltaByte = $inpNum[$i];
+                    $secondDeltaByte = $inpNum[$i + 1];
+                    //echo "Delta $firstDeltaByte, $secondDeltaByte\n";
+                    $i += 2;
+                    $x += $firstDeltaByte;
+                    $y += $secondDeltaByte;
+                    if ($x == $width) {
+                        $x = 0;
+                        //$y++;
+                        // echo "Wrapping line x=$x, y=$y\n";
+                    } else if ($x > $width) {
+                        throw new Exception("Overflow.");
+                    }
+                    if ($y >= $height) {
+                        // Overflow
+                        //echo "ERROR Y overflow on jump, breaking.";
+                        throw new Exception("Bitmap compressed data exceeds image boundary; file is not valid.");
+                    }
+                } else {
+                    //echo "Absolute run of $secondByte bytes\n";
+                    $absoluteLen = $secondByte;
+                    for ($j = 0; $j < $absoluteLen; $j++) {
+                        //echo "Setting byte " . $inpNum[$i + $j] . " x=$x, y=$y (j=$j)\n";
+                        $outpNum[$y][$x] = $inpNum[$i + $j];
+                        $x++;
+                        if ($x == $width) {
+                            $x = 0;
+                            //$y++;
+                            // echo "Wrapping line x=$x, y=$y\n";
+                        } else if ($x > $width) {
+                            throw new Exception("Overflow..");
+                        }
+                        if ($y >= $height) {
+                            // Overflow
+                            //echo "ERROR Y overflow on line-wrap, breaking.";
+                            break 2;
+                        }
+                    }
+                    $i += $absoluteLen;
+                    if ($absoluteLen % 2 != 0) {
+                        //echo "Skipped padding byte\n";
+                        $i++; // skip a padding byte too
+                    }
+                }
+            } else {
+                //echo "Repeat $firstByte instances of $secondByte\n";
+                for ($j = 0; $j < $firstByte; $j++) {
+                    //echo "Setting byte " . $secondByte . " x=$x, y=$y (j=$j)\n";
+                    $outpNum[$y][$x] = $secondByte;
+                    $x++;
+                    if ($x >= $width) {
+                        $x = 0;
+                        //$y++;
+                        //echo "Wrapping line x=$x, y=$y\n";
+                    }
+                    if ($y >= $height) {
+                        // Overflow
+                        //echo "ERROR Y overflow on line-wrap, breaking.";
+                        break 2;
+                    }
+                }
+            }
+        }
+        // Back to string
+        $outStringArr = [];
+        foreach ($outpNum as $row) {
+            $outStringArr[] = pack("C*", ...$row);
+        }
+        return implode("", $outStringArr); //str_repeat("\0", $rowWidth * $height);
     }
 
     public function toRasterImage() : RasterImage

--- a/src/Mike42/GfxPhp/Codec/Bmp/Rle8Decoder.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/Rle8Decoder.php
@@ -1,0 +1,73 @@
+<?php
+namespace Mike42\GfxPhp\Codec\Bmp;
+
+use Exception;
+
+class Rle8Decoder
+{
+    const RLE_ESCAPE = 0;
+    const RLE_END_LINE = 0;
+    const RLE_END_BITMAP = 1;
+    const RLE_JUMP = 2;
+
+    public function decode(string $compressedImgData, int $width, int $height) : string
+    {
+        // Read into numeric input.
+        $inpNum = array_values(unpack("C*", $compressedImgData));
+        $outpNum = $this -> decodeNumbers($inpNum, $width, $height);
+        // Back to string
+        $outStringArr = [];
+        $rowWidth = intdiv((8 * $width + 31), 32) * 4; // Padding to 4-byte boundary: Can this be simplified?
+        $padding = str_repeat("\0", $rowWidth - $width);
+        foreach ($outpNum as $row) {
+            $outStringArr[] = pack("C*", ...$row);
+        }
+        return implode($padding, $outStringArr) . $padding;
+    }
+
+    public function decodeNumbers(array $inpNum, int $width, int $height) : array
+    {
+        // Initialize canvas
+        $buffer = new RleCanvas($width, $height);
+        // read input data, 2 byes at a time
+        $i = 0;
+        $len = intdiv(count($inpNum), 2) * 2;
+        while ($i < $len) {
+            $firstByte = $inpNum[$i];
+            $secondByte = $inpNum[$i + 1];
+            $i += 2;
+            if ($firstByte === self::RLE_ESCAPE) {
+                if ($secondByte === self::RLE_END_LINE) {
+                    $buffer -> endOfLine();
+                } else if ($secondByte === self::RLE_END_BITMAP) {
+                    $buffer -> endOfBitmap();
+                } else if ($secondByte === self::RLE_JUMP) {
+                    // "Delta".
+                    if ($i + 2 > $len) {  // Need 2 more bytes to find out how far to jump
+                        throw new Exception("Unexpected EOF");
+                    }
+                    $deltaX = $inpNum[$i];
+                    $deltaY = $inpNum[$i + 1];
+                    $i += 2;
+                    $buffer -> delta($deltaX, $deltaY);
+                } else {
+                    // "Absolute run". Paste the requested number of bytes onto the canvas
+                    $absoluteLen = $secondByte;
+                    if ($i + $absoluteLen > $len) {
+                        throw new Exception("Unexpected EOF");
+                    }
+                    $bytesToPaste = array_slice($inpNum, $i, $absoluteLen);
+                    $i += $absoluteLen;
+                    if ($absoluteLen % 2 != 0) {
+                        // skip a padding byte too
+                        $i++;
+                    }
+                    $buffer -> absolute($bytesToPaste);
+                }
+            } else {
+                $buffer -> repeat($secondByte, $firstByte);
+            }
+        }
+        return $buffer -> getContents();
+    }
+}

--- a/src/Mike42/GfxPhp/Codec/Bmp/RleCanvas.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/RleCanvas.php
@@ -2,6 +2,8 @@
 
 namespace Mike42\GfxPhp\Codec\Bmp;
 
+use Exception;
+
 /**
  * 2D canvas for writing RLE-encoded BMP data into. A cursor is moved based on the commands issued, and an Exception
  * is thrown if the data goes outside the canvas boundary, or if the data continues after endOfBitmap is called.

--- a/src/Mike42/GfxPhp/Codec/Bmp/RleCanvas.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/RleCanvas.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Mike42\GfxPhp\Codec\Bmp;
+
+/**
+ * 2D canvas for writing RLE-encoded BMP data into. A cursor is moved based on the commands issued, and an Exception
+ * is thrown if the data goes outside the canvas boundary, or if the data continues after endOfBitmap is called.
+ */
+class RleCanvas
+{
+    private $buffer;
+    private $cursorX;
+    private $cursorY;
+    private $width;
+    private $height;
+    private $complete;
+
+    public function __construct(int $width, int $height)
+    {
+        $this -> cursorX = 0;
+        $this -> cursorY = 0;
+        $this -> width = $width;
+        $this -> height = $height;
+        $this -> complete = false;
+        // Initialise empty space
+        $tmp = [];
+        for ($y = 0; $y < $height; $y++) {
+            $tmp[] = array_fill(0, $width, 0);
+        }
+        $this->buffer = $tmp;
+    }
+
+    public function delta(int $deltaX, int $deltaY)
+    {
+        $this -> cursorX += $deltaX;
+        $this -> cursorY += $deltaY;
+    }
+
+    public function endOfLine()
+    {
+        $this -> cursorY++;
+        $this -> cursorX = 0;
+    }
+
+    public function endOfBitmap()
+    {
+        $this -> complete = true;
+    }
+
+    public function set(int $val)
+    {
+        // Range check when we attempt to write the pixel.
+        if ($this -> cursorY < 0 || $this -> cursorY >= $this -> height) {
+            throw new Exception("Bitmap compressed data exceeds image boundary; file is not valid. Y-overflow");
+        }
+        if ($this -> cursorX < 0 || $this -> cursorX >= $this -> width) {
+            throw new Exception("Bitmap compressed data exceeds image boundary; file is not valid. X-overflow");
+        }
+        if ($this -> complete) {
+            throw new Exception("Bitmap compressed data continued after end-of-bitmap code was found; file is not valid.");
+        }
+        // Write the pixel
+        $this -> buffer[$this -> cursorY][$this -> cursorX] = $val;
+        $this -> cursorX++;
+    }
+
+    public function absolute(array $values)
+    {
+        for ($i = 0; $i < count($values); $i++) {
+            $this -> set($values[$i]);
+        }
+    }
+
+    public function repeat(int $val, int $times)
+    {
+        for ($j = 0; $j < $times; $j++) {
+            $this -> set($val);
+        }
+    }
+
+    public function getContents()
+    {
+        return $this -> buffer;
+    }
+}

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -6,563 +6,653 @@ use PHPUnit\Framework\TestCase;
 /**
  * Simple check that files in the BMP Suite can be read, and have the expected dimensions.
  */
-class BmpsuiteTest extends TestCase {
-    function loadImage(string $filename) {
+class BmpsuiteTest extends TestCase
+{
+    function loadImage(string $filename)
+    {
         return Image::fromFile(__DIR__ . "/../resources/bmpsuite/$filename");
     }
 
-    function test_badbitcount() {
+    function test_badbitcount()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badbitcount.bmp");
     }
 
-    function test_badbitssize() {
+    function test_badbitssize()
+    {
         $img = $this -> loadImage("b/badbitssize.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_baddens1() {
+    function test_baddens1()
+    {
         $img = $this -> loadImage("b/baddens1.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_baddens2() {
+    function test_baddens2()
+    {
         $img = $this -> loadImage("b/baddens2.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_badfilesize() {
+    function test_badfilesize()
+    {
         $img = $this -> loadImage("b/badfilesize.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_badheadersize() {
+    function test_badheadersize()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badheadersize.bmp");
     }
 
-    function test_badpalettesize() {
+    function test_badpalettesize()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badpalettesize.bmp");
     }
 
-    function test_badplanes() {
+    function test_badplanes()
+    {
         $img = $this -> loadImage("b/badplanes.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_badrle() {
+    function test_badrle()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badrle.bmp");
     }
 
-    function test_badrle4() {
+    function test_badrle4()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badrle4.bmp");
     }
 
-    function test_badrle4bis() {
+    function test_badrle4bis()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badrle4bis.bmp");
     }
 
-    function test_badrle4ter() {
+    function test_badrle4ter()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badrle4ter.bmp");
     }
 
-    function test_badrlebis() {
+    function test_badrlebis()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badrlebis.bmp");
     }
 
-    function test_badrleter() {
+    function test_badrleter()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badrleter.bmp");
     }
 
-    function test_badwidth() {
+    function test_badwidth()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/badwidth.bmp");
     }
 
-    function test_pal8badindex() {
+    function test_pal8badindex()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/pal8badindex.bmp");
     }
 
-    function test_reallybig() {
+    function test_reallybig()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/reallybig.bmp");
     }
 
-    function test_rgb16_880() {
+    function test_rgb16_880()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/rgb16-880.bmp");
     }
 
-    function test_rletopdown() {
+    function test_rletopdown()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/rletopdown.bmp");
     }
 
-    function test_shortfile() {
+    function test_shortfile()
+    {
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("b/shortfile.bmp");
     }
 
-    function test_pal1() {
+    function test_pal1()
+    {
         $img = $this -> loadImage("g/pal1.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal1bg() {
+    function test_pal1bg()
+    {
         $img = $this -> loadImage("g/pal1bg.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal1wb() {
+    function test_pal1wb()
+    {
         $img = $this -> loadImage("g/pal1wb.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal4() {
+    function test_pal4()
+    {
         $img = $this -> loadImage("g/pal4.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal4gs() {
+    function test_pal4gs()
+    {
         $img = $this -> loadImage("g/pal4gs.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal4rle() {
+    function test_pal4rle()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal4rle.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8_0() {
+    function test_pal8_0()
+    {
         $img = $this -> loadImage("g/pal8-0.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8() {
+    function test_pal8()
+    {
         $img = $this -> loadImage("g/pal8.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8gs() {
+    function test_pal8gs()
+    {
         $img = $this -> loadImage("g/pal8gs.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8nonsquare() {
+    function test_pal8nonsquare()
+    {
         $img = $this -> loadImage("g/pal8nonsquare.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(32, $img -> getHeight());
     }
 
-    function test_pal8os2() {
+    function test_pal8os2()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8os2.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8rle() {
+    function test_pal8rle()
+    {
         $img = $this -> loadImage("g/pal8rle.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8topdown() {
+    function test_pal8topdown()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8topdown.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8v4() {
+    function test_pal8v4()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8v4.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8v5() {
+    function test_pal8v5()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8v5.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8w124() {
+    function test_pal8w124()
+    {
         $img = $this -> loadImage("g/pal8w124.bmp");
         $this -> assertEquals(124, $img -> getWidth());
         $this -> assertEquals(61, $img -> getHeight());
     }
 
-    function test_pal8w125() {
+    function test_pal8w125()
+    {
         $img = $this -> loadImage("g/pal8w125.bmp");
         $this -> assertEquals(125, $img -> getWidth());
         $this -> assertEquals(62, $img -> getHeight());
     }
 
-    function test_pal8w126() {
+    function test_pal8w126()
+    {
         $img = $this -> loadImage("g/pal8w126.bmp");
         $this -> assertEquals(126, $img -> getWidth());
         $this -> assertEquals(63, $img -> getHeight());
     }
 
-    function test_rgb16_565() {
+    function test_rgb16_565()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/rgb16-565.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb16_565pal() {
+    function test_rgb16_565pal()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/rgb16-565pal.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb16() {
+    function test_rgb16()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/rgb16.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb16bfdef() {
+    function test_rgb16bfdef()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/rgb16bfdef.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb24() {
+    function test_rgb24()
+    {
         $img = $this -> loadImage("g/rgb24.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb24pal() {
+    function test_rgb24pal()
+    {
         $img = $this -> loadImage("g/rgb24pal.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb32() {
+    function test_rgb32()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/rgb32.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb32bf() {
+    function test_rgb32bf()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/rgb32bf.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb32bfdef() {
+    function test_rgb32bfdef()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/rgb32bfdef.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal1huff() {
+    function test_pal1huff()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal1huff.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal1p1() {
+    function test_pal1p1()
+    {
         $img = $this -> loadImage("q/pal1p1.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal2() {
+    function test_pal2()
+    {
         $img = $this -> loadImage("q/pal2.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal2color() {
+    function test_pal2color()
+    {
         $img = $this -> loadImage("q/pal2color.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal4rlecut() {
+    function test_pal4rlecut()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal4rlecut.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal4rletrns() {
+    function test_pal4rletrns()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal4rletrns.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8offs() {
+    function test_pal8offs()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8offs.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8os2_hs() {
+    function test_pal8os2_hs()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2-hs.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8os2_sz() {
+    function test_pal8os2_sz()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2-sz.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8os2sp() {
+    function test_pal8os2sp()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2sp.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8os2v2_16() {
+    function test_pal8os2v2_16()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2v2-16.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8os2v2_40sz() {
+    function test_pal8os2v2_40sz()
+    {
         $img = $this -> loadImage("q/pal8os2v2-40sz.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8os2v2_sz() {
+    function test_pal8os2v2_sz()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2v2-sz.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8os2v2() {
+    function test_pal8os2v2()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2v2.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8oversizepal() {
+    function test_pal8oversizepal()
+    {
         $img = $this -> loadImage("q/pal8oversizepal.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8rlecut() {
+    function test_pal8rlecut()
+    {
         $img = $this -> loadImage("q/pal8rlecut.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_pal8rletrns() {
+    function test_pal8rletrns()
+    {
         $img = $this -> loadImage("q/pal8rletrns.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb16_231() {
+    function test_rgb16_231()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb16-231.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb16_3103() {
+    function test_rgb16_3103()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb16-3103.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb16faketrns() {
+    function test_rgb16faketrns()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb16faketrns.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb24jpeg() {
+    function test_rgb24jpeg()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb24jpeg.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb24largepal() {
+    function test_rgb24largepal()
+    {
         $img = $this -> loadImage("q/rgb24largepal.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb24lprof() {
+    function test_rgb24lprof()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb24lprof.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb24png() {
+    function test_rgb24png()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb24png.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb24prof() {
+    function test_rgb24prof()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb24prof.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb24prof2() {
+    function test_rgb24prof2()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb24prof2.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb32_111110() {
+    function test_rgb32_111110()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb32-111110.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb32_7187() {
+    function test_rgb32_7187()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb32-7187.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb32_xbgr() {
+    function test_rgb32_xbgr()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb32-xbgr.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb32fakealpha() {
+    function test_rgb32fakealpha()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb32fakealpha.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgb32h52() {
+    function test_rgb32h52()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb32h52.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgba16_1924() {
+    function test_rgba16_1924()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba16-1924.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgba16_4444() {
+    function test_rgba16_4444()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba16-4444.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgba16_5551() {
+    function test_rgba16_5551()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba16-5551.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgba32_1010102() {
+    function test_rgba32_1010102()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba32-1010102.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgba32_61754() {
+    function test_rgba32_61754()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba32-61754.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgba32_81284() {
+    function test_rgba32_81284()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba32-81284.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgba32() {
+    function test_rgba32()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba32.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgba32abf() {
+    function test_rgba32abf()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba32abf.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_rgba32h56() {
+    function test_rgba32h56()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba32h56.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
-    function test_ba_bm() {
+    function test_ba_bm()
+    {
         $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("x/ba-bm.bmp");
         $this -> assertEquals(1, $img -> getWidth());

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -185,7 +185,6 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_pal8rle() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8rle.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -392,14 +391,12 @@ class BmpsuiteTest extends TestCase {
     }
 
     function test_pal8rlecut() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8rlecut.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal8rletrns() {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8rletrns.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());

--- a/test/unit/Codec/BmpCodecTest.php
+++ b/test/unit/Codec/BmpCodecTest.php
@@ -5,25 +5,27 @@ use PHPUnit\Framework\TestCase;
 use Mike42\GfxPhp\RgbRasterImage;
 
 class BmpCodecTest extends TestCase
-{    
-    const BMP_IMAGE = "BM:\x00\x00\x00\x00\x00\x00\x006\x00\x00\x00(\x00\x00" . 
+{
+
+    const BMP_IMAGE = "BM:\x00\x00\x00\x00\x00\x00\x006\x00\x00\x00(\x00\x00" .
             "\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x18\x00" .
             "\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01".
             "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff" .
             "\xff\x00";
 
-    public function testBmpEncode() {
+    public function testBmpEncode()
+    {
         $encoder = new BmpCodec();
         $image = RgbRasterImage::create(1, 1);
         $imageStr = $encoder -> encode($image, 'bmp');
         $this -> assertEquals(self::BMP_IMAGE, $imageStr);
     }
 
-    public function testBmpDecode() {
+    public function testBmpDecode()
+    {
         $decoder = new BmpCodec();
         $image = $decoder -> decode(self::BMP_IMAGE);
         $this -> assertEquals(1, $image -> getWidth());
         $this -> assertEquals(1, $image -> getHeight());
     }
 }
-

--- a/test/unit/Codec/Rle8DecoderTest.php
+++ b/test/unit/Codec/Rle8DecoderTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Mike42\GfxPhp\Codec\Bmp;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class Rle8DecoderTest extends TestCase
+{
+    public function testDecodeEmpty()
+    {
+        $decoder = new Rle8Decoder();
+        $result = $decoder -> decodeNumbers([], 0, 0);
+        $this -> assertEquals([], $result);
+    }
+
+    public function testDecodeEmpty2()
+    {
+        $decoder = new Rle8Decoder();
+        $result = $decoder -> decodeNumbers([
+            0, 1 // End of bitmap
+        ], 0, 0);
+        $this -> assertEquals([], $result);
+    }
+
+    public function testDecodeRun()
+    {
+        $decoder = new Rle8Decoder();
+        $result = $decoder -> decodeNumbers([
+            3, 1, // 3 1's
+            0, 0, // Line break
+            3, 3, // 3 3's
+            0, 0, // Line break
+            3, 5, // 3 5's
+            0, 1 // End of bitmap
+        ], 3, 3);
+        $expected = [
+          [1, 1, 1],
+          [3, 3, 3],
+          [5, 5, 5]
+        ];
+        $this -> assertEquals($expected, $result);
+    }
+
+    public function testRunTooWide()
+    {
+        $this -> expectException(Exception::class);
+        $decoder = new Rle8Decoder();
+        $result = $decoder -> decodeNumbers([
+            4, 1, // 4 1's (x-direction overflow)
+            0, 0, // Line break
+            3, 3, // 3 3's
+            0, 0, // Line break
+            3, 5, // 3 5's
+            0, 1 // End of bitmap
+        ], 3, 3);
+        $expected = [
+            [1, 1, 1],
+            [3, 3, 3],
+            [5, 5, 5]
+        ];
+        $this -> assertEquals($expected, $result);
+    }
+
+    public function testRunTooTall()
+    {
+        $this -> expectException(Exception::class);
+        $decoder = new Rle8Decoder();
+        $result = $decoder -> decodeNumbers([
+            3, 1, // 3 1's
+            0, 0, // Line break
+            3, 3, // 3 3's
+            0, 0, // Line break
+            3, 5, // 3 5's
+            0, 0, // Line break
+            3, 6, // 3 6's (y-direction overflow)
+            0, 1 // End of bitmap
+        ], 3, 3);
+        $expected = [
+            [1, 1, 1],
+            [3, 3, 3],
+            [5, 5, 5]
+        ];
+        $this -> assertEquals($expected, $result);
+    }
+
+
+    public function testDeltaDiagonal()
+    {
+        $decoder = new Rle8Decoder();
+        $result = $decoder -> decodeNumbers([
+            0, 2, // Jump..
+            2, 2, // .. diagonally
+            1, 1, // Print 1
+            0, 1 // End of bitmap
+        ], 3, 3);
+        $expected = [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 1]
+        ];
+        $this -> assertEquals($expected, $result);
+    }
+
+    public function testDeltaRight()
+    {
+        $decoder = new Rle8Decoder();
+        $result = $decoder -> decodeNumbers([
+            0, 2, // Jump..
+            2, 0, // .. right
+            1, 1, // Print 1
+            0, 1 // End of bitmap
+        ], 3, 3);
+        $expected = [
+            [0, 0, 1],
+            [0, 0, 0],
+            [0, 0, 0]
+        ];
+        $this -> assertEquals($expected, $result);
+    }
+
+    public function testDeltaDown()
+    {
+        $decoder = new Rle8Decoder();
+        $result = $decoder -> decodeNumbers([
+            0, 2, // Jump..
+            0, 2, // .. down
+            1, 1, // Print 1
+            0, 1 // End of bitmap
+        ], 3, 3);
+        $expected = [
+            [0, 0, 0],
+            [0, 0, 0],
+            [1, 0, 0]
+        ];
+        $this -> assertEquals($expected, $result);
+    }
+
+    public function testAbsolute()
+    {
+        $decoder = new Rle8Decoder();
+        $result = $decoder -> decodeNumbers([
+            0, 3, 1, 2, 3, 0, // Absolute run of 3 pixels + 1 pixel of padding
+            0, 0, // Line break
+            0, 3, 4, 5, 6, 0, // 3 pixels
+            0, 0, // Line break
+            0, 3, 7, 8, 9, 0, // 3 pixels
+            0, 0, // Line break
+            0, 1 // End of bitmap
+        ], 3, 3);
+        $expected = [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9]
+        ];
+        $this -> assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
This allows the BMP reader to handle RLE8-ended bitmaps, which may be used in 8-bit indexed bitmaps.

Reference:

- #35 
