### PR TITLE
Implement RLE4 bitmap decode

### DIFF
--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
@@ -110,6 +110,16 @@ class BmpFile
                 }
                 break;
             case BmpInfoHeader::B1_RLE4:
+                if ($infoHeader -> bpp !== 4) {
+                    throw new Exception("RLE4 compression only valid for 4-bit images");
+                }
+                $decoder = new Rle4Decoder();
+                $uncompressedImgData = $decoder -> decode($compressedImgData, $infoHeader -> width, $infoHeader -> height);
+                $actualSize = strlen($uncompressedImgData);
+                if ($uncompressedImgSizeBytes !== $actualSize) {
+                    throw new Exception("RLE4 decode failed. Expected $uncompressedImgSizeBytes bytes uncompressed, got $actualSize");
+                }
+                break;
             case BmpInfoHeader::B1_BITFILEDS:
             case BmpInfoHeader::B1_JPEG:
             case BmpInfoHeader::B1_PNG:

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -175,7 +175,6 @@ class BmpsuiteTest extends TestCase
 
     function test_pal4rle()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal4rle.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());


### PR DESCRIPTION
This change adds RLE4 support to the bitmap decoder. The implementation is a clone of the existing RLE8 decoder with edits to use a different pixel depth, since a generic decoder would be quite convoluted.

Reference:

- #35