### PR TITLE
Implement top-down storage for uncompressed BMP images

### DIFF
--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
@@ -63,7 +63,8 @@ class BmpInfoHeader
     ) {
         $this -> headerSize = $headerSize;
         $this -> width = $width;
-        $this -> height = $height;
+        // Not possible to read signed little-endian 32-bit long with unpack(), but height may be negative.
+        $this -> height = ($height >= (2**31)) ? ($height - (2**32)) : $height;
         $this -> planes = $planes;
         $this -> bpp = $bpp;
         $this -> compression = $compression;

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -225,7 +225,6 @@ class BmpsuiteTest extends TestCase
 
     function test_pal8topdown()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("g/pal8topdown.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());


### PR DESCRIPTION
This allows `pal8topdown.bmp` from the BMP test suite to be read.

Ref:

- #35 
