### PR TITLE
Implement skipping to data offset found in BMP file header

### DIFF
--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
@@ -165,6 +165,7 @@ class BmpInfoHeader
 
     private static function readBitmapInfoHeader(DataInputStream $data) : BmpInfoHeader
     {
+        $headerSize = self::BITMAPINFOHEADER_SIZE;
         $infoFields = self::getInfoFields($data);
         // Quirk- A BITMAPINFOHEADER specifying B1_BITFIELDS has 12 bytes of masks after it.
         // In later versions, this information is part of the header itself, and is read unconditionally.
@@ -178,14 +179,16 @@ class BmpInfoHeader
             $redMask = $rgbMaskFields['redMask'];
             $greenMask = $rgbMaskFields['greenMask'];
             $blueMask = $rgbMaskFields['blueMask'];
+            $headerSize += 12;
         }
         if ($infoFields['compression'] === self::B1_ALPHABITFIELDS) {
             // we might or might not need to read a 4-byte alpha mask too, depending on the compression type.
             $alphaMaskFields = self::getV3fields($data);
             $alphaMask = $alphaMaskFields['alphaMask'];
+            $headerSize += 4;
         }
         return new BmpInfoHeader(
-            self::BITMAPINFOHEADER_SIZE,
+            $headerSize,
             $infoFields['width'],
             $infoFields['height'],
             $infoFields['planes'],

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -330,10 +330,9 @@ class BmpsuiteTest extends TestCase
 
     function test_pal1huff()
     {
-        $this -> markTestSkipped("Not implemented");
+        // Fails here because of unsupported header type, but compression format is not widely implemented either.
+        $this -> expectException(Exception::class);
         $img = $this -> loadImage("q/pal1huff.bmp");
-        $this -> assertEquals(127, $img -> getWidth());
-        $this -> assertEquals(64, $img -> getHeight());
     }
 
     function test_pal1p1()
@@ -359,7 +358,6 @@ class BmpsuiteTest extends TestCase
 
     function test_pal4rlecut()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal4rlecut.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -367,7 +365,6 @@ class BmpsuiteTest extends TestCase
 
     function test_pal4rletrns()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal4rletrns.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -375,7 +372,6 @@ class BmpsuiteTest extends TestCase
 
     function test_pal8offs()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8offs.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());


### PR DESCRIPTION
This allows the file `pal8offs.bmp` from the BMP suite to be read.

Ref:

- #35