### PR TITLE
BMP format improvements

### DIFF
--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
@@ -86,6 +86,14 @@ class BmpFile
                 $data -> advance($fileHeader -> offset - $calculatedOffset);
             }
         }
+        if ($infoHeader -> headerSize == BmpInfoHeader::OS22XBITMAPHEADER_FULL_SIZE || $infoHeader -> headerSize == BmpInfoHeader::OS22XBITMAPHEADER_MIN_SIZE) {
+            // Some compression modes in OS/2 V2 bitmaps use the same numeric ID' as unrelated Windows BMP compression modes, but are not supported.
+            if ($infoHeader -> compression != BmpInfoHeader::B1_RGB &&
+                $infoHeader -> compression != BmpInfoHeader::B1_RLE4 &&
+                $infoHeader -> compression != BmpInfoHeader::B1_RLE8) {
+                throw new Exception("Compression method not implemented for OS/2 V2 bitmaps");
+            }
+        }
         // Determine compressed & uncompressed size
         $topDown = false;
         $height = $infoHeader -> height;

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
@@ -110,6 +110,7 @@ class BmpFile
         switch ($infoHeader -> compression) {
             case BmpInfoHeader::B1_RGB:
             case BmpInfoHeader::B1_BITFILEDS:
+            case BmpInfoHeader::B1_ALPHABITFIELDS:
                 $uncompressedImgData = $compressedImgData;
                 break;
             case BmpInfoHeader::B1_RLE8:
@@ -136,7 +137,6 @@ class BmpFile
                 break;
             case BmpInfoHeader::B1_JPEG:
             case BmpInfoHeader::B1_PNG:
-            case BmpInfoHeader::B1_ALPHABITFIELDS:
             case BmpInfoHeader::B1_CMYK:
             case BmpInfoHeader::B1_CMYKRLE8:
             case BmpInfoHeader::B1_CMYKRLE4:

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
@@ -335,10 +335,7 @@ class BmpInfoHeader
     {
         $coreData = $data -> read(self::OS22XBITMAPHEADER_MIN_SIZE - 4);
         $coreFields = unpack("Vwidth/Vheight/vplanes/vbpp", $coreData);
-        if ($size > self::OS22XBITMAPHEADER_MIN_SIZE) {
-            // Skip more bytes
-            $extraData = $data -> read(self::OS22XBITMAPHEADER_FULL_SIZE - self::OS22XBITMAPHEADER_MIN_SIZE);
-        } else {
+        if ($size == self::OS22XBITMAPHEADER_MIN_SIZE) {
             return new BmpInfoHeader(
                 self::OS22XBITMAPHEADER_MIN_SIZE,
                 $coreFields['width'],
@@ -347,6 +344,21 @@ class BmpInfoHeader
                 $coreFields['bpp']
             );
         }
-        throw new Exception("OS22XBITMAPHEADER at full size not supported");
+        // Read up to the full header size
+        $extraData = $data -> read(self::OS22XBITMAPHEADER_FULL_SIZE - self::OS22XBITMAPHEADER_MIN_SIZE);
+        $extraFields =  unpack("Vcompression/VcompressedSize/VhorizontalRes/VverticalRes/Vcolors/VimportantColors/vunits/vreserved/vrecording/vrendering/Vsize1/Vsize2/VcolorEncoding/Videntifier", $extraData);
+        return new BmpInfoHeader(
+            self::OS22XBITMAPHEADER_FULL_SIZE,
+            $coreFields['width'],
+            $coreFields['height'],
+            $coreFields['planes'],
+            $coreFields['bpp'],
+            $extraFields['compression'],
+            $extraFields['compressedSize'],
+            $extraFields['horizontalRes'],
+            $extraFields['verticalRes'],
+            $extraFields['colors'],
+            $extraFields['importantColors']
+        ); // Other fields are ignored.
     }
 }

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -330,7 +330,6 @@ class BmpsuiteTest extends TestCase
 
     function test_pal1huff()
     {
-        // Fails here because of unsupported header type, but compression format is not widely implemented either.
         $this -> expectException(Exception::class);
         $img = $this -> loadImage("q/pal1huff.bmp");
     }
@@ -400,7 +399,6 @@ class BmpsuiteTest extends TestCase
 
     function test_pal8os2v2_16()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2v2-16.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -590,7 +590,6 @@ class BmpsuiteTest extends TestCase
 
     function test_rgba32_81284()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba32-81284.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -605,7 +604,6 @@ class BmpsuiteTest extends TestCase
 
     function test_rgba32abf()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgba32abf.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -473,7 +473,7 @@ class BmpsuiteTest extends TestCase
 
     function test_rgb24jpeg()
     {
-        $this -> markTestSkipped("Not implemented");
+        $this -> expectException(Exception::class);
         $img = $this -> loadImage("q/rgb24jpeg.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -488,7 +488,6 @@ class BmpsuiteTest extends TestCase
 
     function test_rgb24lprof()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb24lprof.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -496,7 +495,7 @@ class BmpsuiteTest extends TestCase
 
     function test_rgb24png()
     {
-        $this -> markTestSkipped("Not implemented");
+        $this -> expectException(Exception::class);
         $img = $this -> loadImage("q/rgb24png.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -504,7 +503,6 @@ class BmpsuiteTest extends TestCase
 
     function test_rgb24prof()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb24prof.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -512,7 +510,6 @@ class BmpsuiteTest extends TestCase
 
     function test_rgb24prof2()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/rgb24prof2.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());

--- a/test/integration/BmpsuiteTest.php
+++ b/test/integration/BmpsuiteTest.php
@@ -413,7 +413,6 @@ class BmpsuiteTest extends TestCase
 
     function test_pal8os2v2_sz()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2v2-sz.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -421,7 +420,6 @@ class BmpsuiteTest extends TestCase
 
     function test_pal8os2v2()
     {
-        $this -> markTestSkipped("Not implemented");
         $img = $this -> loadImage("q/pal8os2v2.bmp");
         $this -> assertEquals(127, $img -> getWidth());
         $this -> assertEquals(64, $img -> getHeight());
@@ -613,9 +611,8 @@ class BmpsuiteTest extends TestCase
 
     function test_ba_bm()
     {
-        $this -> markTestSkipped("Not implemented");
+        // Different container format, not recognised as bitmap at all
+        $this -> expectException(Exception::class);
         $img = $this -> loadImage("x/ba-bm.bmp");
-        $this -> assertEquals(1, $img -> getWidth());
-        $this -> assertEquals(1, $img -> getHeight());
     }
 }


### PR DESCRIPTION
- Adds support for OS/2 2.x BMP header format
- Adds support for reading BMP files with embedded ICC color profile (the profile is now ignored, where previously the file could not be read)
- Unit tests for rejection of JPEG/PNG-compressed images, alternative OS/2 container (neither are commonly used)

Ref:

- #35