### PR TITLE
PHP version updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     ],
     "config": {
         "platform": {
-            "php": "7.0.0"
+            "php": "8.2.0"
         }
     },
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=8.1.0"
     },
     "autoload": {
         "psr-4": {
@@ -24,8 +24,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
-        "squizlabs/php_codesniffer": "^3.3.1",
+        "phpunit/phpunit": "^10",
+        "squizlabs/php_codesniffer": "^3.8.0",
         "phpbench/phpbench": "@dev"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
     "require-dev": {
         "phpunit/phpunit": "^10",
         "squizlabs/php_codesniffer": "^3.8.0",
-        "phpbench/phpbench": "@dev"
+        "phpbench/phpbench": "^1.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "005cfd749b2994390534201dd16a746b",
+    "content-hash": "6b705f8acd3882349f6a5911a0978ad7",
     "packages": [],
     "packages-dev": [
         {
@@ -490,16 +490,16 @@
         },
         {
             "name": "phpbench/phpbench",
-            "version": "dev-master",
+            "version": "1.2.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "6998f01ee068e30009328768aef1d8ce48f339f1"
+                "reference": "f7000319695cfad04a57fc64bf7ef7abdf4c437c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/6998f01ee068e30009328768aef1d8ce48f339f1",
-                "reference": "6998f01ee068e30009328768aef1d8ce48f339f1",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/f7000319695cfad04a57fc64bf7ef7abdf4c437c",
+                "reference": "f7000319695cfad04a57fc64bf7ef7abdf4c437c",
                 "shasum": ""
             },
             "require": {
@@ -515,35 +515,29 @@
                 "phpbench/dom": "~0.3.3",
                 "psr/log": "^1.1 || ^2.0 || ^3.0",
                 "seld/jsonlint": "^1.1",
-                "symfony/console": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/console": "^4.2 || ^5.0  || ^6.0 || ^7.0",
                 "symfony/filesystem": "^4.2 || ^5.0 || ^6.0 || ^7.0",
                 "symfony/finder": "^4.2 || ^5.0 || ^6.0 || ^7.0",
                 "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0 || ^7.0",
                 "symfony/process": "^4.2 || ^5.0 || ^6.0 || ^7.0",
                 "webmozart/glob": "^4.6"
             },
-            "replace": {
-                "symfony/polyfill-php80": "*",
-                "symfony/polyfill-php81": "*"
-            },
             "require-dev": {
                 "dantleech/invoke": "^2.0",
-                "ergebnis/composer-normalize": "^2.39",
                 "friendsofphp/php-cs-fixer": "^3.0",
                 "jangregor/phpstan-prophecy": "^1.0",
                 "phpspec/prophecy": "dev-master",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^10.4",
-                "rector/rector": "^0.18.11",
+                "phpunit/phpunit": "^10.0",
+                "rector/rector": "^0.18.10",
                 "symfony/error-handler": "^5.2 || ^6.0 || ^7.0",
                 "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
                 "ext-xdebug": "For Xdebug profiling extension."
             },
-            "default-branch": true,
             "bin": [
                 "bin/phpbench"
             ],
@@ -582,7 +576,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/master"
+                "source": "https://github.com/phpbench/phpbench/tree/1.2.15"
             },
             "funding": [
                 {
@@ -590,7 +584,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-24T09:38:48+00:00"
+            "time": "2023-11-29T12:21:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3240,9 +3234,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "phpbench/phpbench": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,92 +4,41 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76c41e8676acf15ba354f94a3f128604",
+    "content-hash": "005cfd749b2994390534201dd16a746b",
     "packages": [],
     "packages-dev": [
         {
-            "name": "beberlei/assert",
-            "version": "v2.9.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/beberlei/assert.git",
-                "reference": "ec9e4cf0b63890edce844ee3922e2b95a526e936"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/beberlei/assert/zipball/ec9e4cf0b63890edce844ee3922e2b95a526e936",
-                "reference": "ec9e4cf0b63890edce844ee3922e2b95a526e936",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.1.1",
-                "phpunit/phpunit": "^4.8.35|^5.7"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Assert\\": "lib/Assert"
-                },
-                "files": [
-                    "lib/Assert/functions.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de",
-                    "role": "Lead Developer"
-                },
-                {
-                    "name": "Richard Quadling",
-                    "email": "rquadling@gmail.com",
-                    "role": "Collaborator"
-                }
-            ],
-            "description": "Thin assertion library for input validation in business models.",
-            "keywords": [
-                "assert",
-                "assertion",
-                "validation"
-            ],
-            "time": "2018-06-11T17:15:25+00:00"
-        },
-        {
             "name": "doctrine/annotations",
-            "version": "v1.4.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
-                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/lexer": "1.*",
-                "php": "^5.6 || ^7.0"
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^5.7"
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.8.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6",
+                "vimeo/psalm": "^4.10"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
@@ -101,16 +50,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -122,94 +71,46 @@
                 }
             ],
             "description": "Docblock Annotations Parser",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
             "keywords": [
                 "annotations",
                 "docblock",
                 "parser"
             ],
-            "time": "2017-02-24T16:22:25+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.1"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3,<8.0-DEV"
-            },
-            "require-dev": {
-                "athletic/athletic": "~0.1.8",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2023-02-02T22:02:53+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "v1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+                "reference": "84a527db05647743d50373e0ec53a152f2cde568"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/84a527db05647743d50373e0ec53a152f2cde568",
+                "reference": "84a527db05647743d50373e0ec53a152f2cde568",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^9.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^5.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Lexer\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -218,195 +119,81 @@
             ],
             "authors": [
                 {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
                     "name": "Guilherme Blanco",
                     "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "http://www.doctrine-project.org",
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
             "keywords": [
+                "annotations",
+                "docblock",
                 "lexer",
-                "parser"
+                "parser",
+                "php"
             ],
-            "time": "2014-09-09T13:34:57+00:00"
-        },
-        {
-            "name": "lstrojny/functional-php",
-            "version": "1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lstrojny/functional-php.git",
-                "reference": "f5b3b4424dcddb406d3dcfcae0d1bc0060099a78"
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/3.0.0"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lstrojny/functional-php/zipball/f5b3b4424dcddb406d3dcfcae0d1bc0060099a78",
-                "reference": "f5b3b4424dcddb406d3dcfcae0d1bc0060099a78",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Functional\\": "src/Functional"
-                },
-                "files": [
-                    "src/Functional/Average.php",
-                    "src/Functional/ButLast.php",
-                    "src/Functional/Capture.php",
-                    "src/Functional/ConstFunction.php",
-                    "src/Functional/CompareOn.php",
-                    "src/Functional/CompareObjectHashOn.php",
-                    "src/Functional/Compose.php",
-                    "src/Functional/Concat.php",
-                    "src/Functional/Contains.php",
-                    "src/Functional/Curry.php",
-                    "src/Functional/CurryN.php",
-                    "src/Functional/Difference.php",
-                    "src/Functional/DropFirst.php",
-                    "src/Functional/DropLast.php",
-                    "src/Functional/Each.php",
-                    "src/Functional/Equal.php",
-                    "src/Functional/ErrorToException.php",
-                    "src/Functional/Every.php",
-                    "src/Functional/False.php",
-                    "src/Functional/Falsy.php",
-                    "src/Functional/Filter.php",
-                    "src/Functional/First.php",
-                    "src/Functional/FirstIndexOf.php",
-                    "src/Functional/FlatMap.php",
-                    "src/Functional/Flatten.php",
-                    "src/Functional/Flip.php",
-                    "src/Functional/GreaterThan.php",
-                    "src/Functional/GreaterThanOrEqual.php",
-                    "src/Functional/Group.php",
-                    "src/Functional/Head.php",
-                    "src/Functional/Id.php",
-                    "src/Functional/IfElse.php",
-                    "src/Functional/Identical.php",
-                    "src/Functional/IndexesOf.php",
-                    "src/Functional/Intersperse.php",
-                    "src/Functional/Invoke.php",
-                    "src/Functional/InvokeFirst.php",
-                    "src/Functional/InvokeIf.php",
-                    "src/Functional/InvokeLast.php",
-                    "src/Functional/Invoker.php",
-                    "src/Functional/Last.php",
-                    "src/Functional/LastIndexOf.php",
-                    "src/Functional/LessThan.php",
-                    "src/Functional/LessThanOrEqual.php",
-                    "src/Functional/LexicographicCompare.php",
-                    "src/Functional/Map.php",
-                    "src/Functional/Match.php",
-                    "src/Functional/Maximum.php",
-                    "src/Functional/Memoize.php",
-                    "src/Functional/Minimum.php",
-                    "src/Functional/None.php",
-                    "src/Functional/Not.php",
-                    "src/Functional/PartialAny.php",
-                    "src/Functional/PartialLeft.php",
-                    "src/Functional/PartialMethod.php",
-                    "src/Functional/PartialRight.php",
-                    "src/Functional/Partition.php",
-                    "src/Functional/Pick.php",
-                    "src/Functional/Pluck.php",
-                    "src/Functional/Poll.php",
-                    "src/Functional/Product.php",
-                    "src/Functional/Ratio.php",
-                    "src/Functional/ReduceLeft.php",
-                    "src/Functional/ReduceRight.php",
-                    "src/Functional/Reindex.php",
-                    "src/Functional/Reject.php",
-                    "src/Functional/Retry.php",
-                    "src/Functional/Select.php",
-                    "src/Functional/SelectKeys.php",
-                    "src/Functional/SequenceConstant.php",
-                    "src/Functional/SequenceExponential.php",
-                    "src/Functional/SequenceLinear.php",
-                    "src/Functional/Some.php",
-                    "src/Functional/Sort.php",
-                    "src/Functional/Sum.php",
-                    "src/Functional/SuppressError.php",
-                    "src/Functional/Tap.php",
-                    "src/Functional/Tail.php",
-                    "src/Functional/TailRecursion.php",
-                    "src/Functional/True.php",
-                    "src/Functional/Truthy.php",
-                    "src/Functional/Unique.php",
-                    "src/Functional/With.php",
-                    "src/Functional/Zip.php",
-                    "src/Functional/ZipAll.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Lars Strojny",
-                    "email": "lstrojny@php.net",
-                    "homepage": "http://usrportage.de"
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
                 },
                 {
-                    "name": "Max Beutel",
-                    "email": "nash12@gmail.com"
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Functional primitives for PHP",
-            "keywords": [
-                "functional"
-            ],
-            "time": "2018-12-03T16:47:05+00:00"
+            "time": "2022-12-15T16:57:16+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -420,32 +207,99 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
-            "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "name": "nikic/php-parser",
+            "version": "v4.18.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+            },
+            "time": "2023-12-10T21:03:43+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -475,24 +329,28 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -522,32 +380,39 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpbench/container",
-            "version": "1.2",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/container.git",
-                "reference": "c0e3cbf1cd8f867c70b029cb6d1b0b39fe6d409d"
+                "reference": "a59b929e00b87b532ca6d0edd8eca0967655af33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/container/zipball/c0e3cbf1cd8f867c70b029cb6d1b0b39fe6d409d",
-                "reference": "c0e3cbf1cd8f867c70b029cb6d1b0b39fe6d409d",
+                "url": "https://api.github.com/repos/phpbench/container/zipball/a59b929e00b87b532ca6d0edd8eca0967655af33",
+                "reference": "a59b929e00b87b532ca6d0edd8eca0967655af33",
                 "shasum": ""
             },
             "require": {
-                "psr/container": "^1.0"
+                "psr/container": "^1.0|^2.0",
+                "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36"
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "phpstan/phpstan": "^0.12.52",
+                "phpunit/phpunit": "^8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -566,28 +431,34 @@
                 }
             ],
             "description": "Simple, configurable, service container.",
-            "time": "2018-02-12T08:08:59+00:00"
+            "support": {
+                "issues": "https://github.com/phpbench/container/issues",
+                "source": "https://github.com/phpbench/container/tree/2.2.2"
+            },
+            "time": "2023-10-30T13:38:26+00:00"
         },
         {
             "name": "phpbench/dom",
-            "version": "0.2.0",
+            "version": "0.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/dom.git",
-                "reference": "b135378dd0004c05ba5446aeddaf0b83339c1c4c"
+                "reference": "786a96db538d0def931f5b19225233ec42ec7a72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/dom/zipball/b135378dd0004c05ba5446aeddaf0b83339c1c4c",
-                "reference": "b135378dd0004c05ba5446aeddaf0b83339c1c4c",
+                "url": "https://api.github.com/repos/phpbench/dom/zipball/786a96db538d0def931f5b19225233ec42ec7a72",
+                "reference": "786a96db538d0def931f5b19225233ec42ec7a72",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^5.4|^7.0"
+                "php": "^7.3||^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.0||^9.0"
             },
             "type": "library",
             "extra": {
@@ -611,65 +482,83 @@
                 }
             ],
             "description": "DOM wrapper to simplify working with the PHP DOM implementation",
-            "time": "2016-02-27T12:15:56+00:00"
+            "support": {
+                "issues": "https://github.com/phpbench/dom/issues",
+                "source": "https://github.com/phpbench/dom/tree/0.3.3"
+            },
+            "time": "2023-03-06T23:46:57+00:00"
         },
         {
             "name": "phpbench/phpbench",
-            "version": "0.14.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "ea2c7ca1cdbfa952b8d50c4f36fc233dbfabe3c9"
+                "reference": "6998f01ee068e30009328768aef1d8ce48f339f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/ea2c7ca1cdbfa952b8d50c4f36fc233dbfabe3c9",
-                "reference": "ea2c7ca1cdbfa952b8d50c4f36fc233dbfabe3c9",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/6998f01ee068e30009328768aef1d8ce48f339f1",
+                "reference": "6998f01ee068e30009328768aef1d8ce48f339f1",
                 "shasum": ""
             },
             "require": {
-                "beberlei/assert": "^2.4",
-                "doctrine/annotations": "^1.2.7",
+                "doctrine/annotations": "^2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
-                "lstrojny/functional-php": "1.0|^1.2.3",
-                "php": "^7.0",
-                "phpbench/container": "~1.0",
-                "phpbench/dom": "~0.2.0",
-                "seld/jsonlint": "^1.0",
-                "symfony/console": "^2.6|^3.0|^4.0",
-                "symfony/debug": "^2.4|^3.0|^4.0",
-                "symfony/filesystem": "^2.4|^3.0|^4.0",
-                "symfony/finder": "^2.4|^3.0|^4.0",
-                "symfony/options-resolver": "^2.6|^3.0|^4.0",
-                "symfony/process": "^2.1|^3.0|^4.0"
+                "ext-tokenizer": "*",
+                "php": "^8.1",
+                "phpbench/container": "^2.1",
+                "phpbench/dom": "~0.3.3",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "seld/jsonlint": "^1.1",
+                "symfony/console": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/finder": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/process": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+                "webmozart/glob": "^4.6"
+            },
+            "replace": {
+                "symfony/polyfill-php80": "*",
+                "symfony/polyfill-php81": "*"
             },
             "require-dev": {
-                "doctrine/dbal": "^2.4",
-                "liip/rmt": "^1.2",
-                "padraic/phar-updater": "^1.0",
-                "phpstan/phpstan": "^0.8.5",
-                "phpunit/phpunit": "^6.0"
+                "dantleech/invoke": "^2.0",
+                "ergebnis/composer-normalize": "^2.39",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "jangregor/phpstan-prophecy": "^1.0",
+                "phpspec/prophecy": "dev-master",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^10.4",
+                "rector/rector": "^0.18.11",
+                "symfony/error-handler": "^5.2 || ^6.0 || ^7.0",
+                "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "ext-xdebug": "For XDebug profiling extension."
+                "ext-xdebug": "For Xdebug profiling extension."
             },
+            "default-branch": true,
             "bin": [
                 "bin/phpbench"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "lib/Report/Func/functions.php"
+                ],
                 "psr-4": {
                     "PhpBench\\": "lib/",
-                    "PhpBench\\Extensions\\Dbal\\": "extensions/dbal/lib/",
                     "PhpBench\\Extensions\\XDebug\\": "extensions/xdebug/lib/"
                 }
             },
@@ -684,259 +573,65 @@
                 }
             ],
             "description": "PHP Benchmarking Framework",
-            "time": "2017-12-05T15:55:57+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
             "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
+                "benchmarking",
+                "optimization",
+                "performance",
+                "profiling",
+                "testing"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+            "support": {
+                "issues": "https://github.com/phpbench/phpbench/issues",
+                "source": "https://github.com/phpbench/phpbench/tree/master"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "doctrine/instantiator": "~1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
+                    "url": "https://github.com/dantleech",
+                    "type": "github"
                 }
             ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "time": "2017-07-14T14:27:02+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "1.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2023-12-24T09:38:48+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.2",
+            "version": "10.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+                "reference": "78c3b7625965c2513ee96569a4dbb62601784145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/78c3b7625965c2513ee96569a4dbb62601784145",
+                "reference": "78c3b7625965c2513ee96569a4dbb62601784145",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
+                "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -962,29 +657,43 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:36:58+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.11"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T15:38:30+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -999,7 +708,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1009,26 +718,108 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1050,32 +841,43 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1090,7 +892,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1099,69 +901,30 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
                 }
             ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.14",
+            "version": "10.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
+                "reference": "6fce887c71076a73f32fd3e0774a6833fc5c7f19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6fce887c71076a73f32fd3e0774a6833fc5c7f19",
+                "reference": "6fce887c71076a73f32fd3e0774a6833fc5c7f19",
                 "shasum": ""
             },
             "require": {
@@ -1170,35 +933,30 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
-                "phpunit/php-file-iterator": "^1.4.3",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.9",
-                "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
-            },
-            "require-dev": {
-                "ext-pdo": "*"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.5",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.1",
+                "sebastian/global-state": "^6.0.1",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -1206,10 +964,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -1232,41 +993,203 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-02-01T05:22:47+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.3"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-13T07:25:23+00:00"
         },
         {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.10",
+            "name": "psr/cache",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5.11"
-            },
-            "suggest": {
-                "ext-soap": "*"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1285,135 +1208,100 @@
                     "role": "lead"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
             ],
-            "abandoned": true,
-            "time": "2018-08-09T05:50:03+00:00"
+            "time": "2023-02-03T06:58:15+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.0.0",
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "time": "2017-02-14T16:28:37+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
                 }
             ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2018-11-20T15:27:04+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1433,34 +1321,46 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
-                "sebastian/exporter": "^3.1"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^10.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1473,6 +1373,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -1484,10 +1388,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -1497,32 +1397,44 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-14T13:18:12+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "2.0.1",
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1536,45 +1448,120 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
                 {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T10:55:06+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1593,40 +1580,51 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-04-11T05:39:26+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64f51654862e0f5e318db7e9dcc2292c63cdbddc",
+                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1640,6 +1638,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1648,53 +1650,60 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-09-24T13:22:09+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1717,34 +1726,103 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-07-19T07:19:23+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1764,32 +1842,42 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1809,32 +1897,42 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1848,12 +1946,12 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -1861,30 +1959,43 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
-            "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "name": "sebastian/type",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1899,34 +2010,45 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1947,27 +2069,38 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.7.1",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38"
+                "reference": "76d449a358ece77d6f1d6331c68453e657172202"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/d15f59a67ff805a44c50ea0516d2341740f81a38",
-                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/76d449a358ece77d6f1d6331c68453e657172202",
+                "reference": "76d449a358ece77d6f1d6331c68453e657172202",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3 || ^7.0"
+                "php": "^5.3 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpstan/phpstan": "^1.5",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
             },
             "bin": [
                 "bin/jsonlint"
@@ -1986,7 +2119,7 @@
                 {
                     "name": "Jordi Boggiano",
                     "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "homepage": "https://seld.be"
                 }
             ],
             "description": "JSON Linter",
@@ -1996,20 +2129,34 @@
                 "parser",
                 "validator"
             ],
-            "time": "2018-01-24T12:46:19+00:00"
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-18T13:03:25+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.0",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
                 "shasum": ""
             },
             "require": {
@@ -2019,7 +2166,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -2038,60 +2185,90 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
-            "time": "2018-12-19T23:57:18+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T12:32:31+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.6",
+            "version": "v7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "b0878233cb5c4391347e5495089c7af11b8e6201"
+                "reference": "cdce5c684b2f920bb1343deecdfba356ffad83d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/b0878233cb5c4391347e5495089c7af11b8e6201",
-                "reference": "b0878233cb5c4391347e5495089c7af11b8e6201",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cdce5c684b2f920bb1343deecdfba356ffad83d5",
+                "reference": "cdce5c684b2f920bb1343deecdfba356ffad83d5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
-                "symfony/debug": "~2.8|~3.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~3.3",
-                "symfony/dependency-injection": "~3.3",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/filesystem": "~2.8|~3.0",
-                "symfony/http-kernel": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/filesystem": "",
-                "symfony/process": ""
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
@@ -2114,46 +2291,63 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Console Component",
+            "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29T21:27:59+00:00"
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-01T15:10:06+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v3.3.6",
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "7c13ae8ce1e2adbbd574fc39de7be498e1284e13"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/7c13ae8ce1e2adbbd574fc39de7be498e1284e13",
-                "reference": "7c13ae8ce1e2adbbd574fc39de7be498e1284e13",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
-            },
-            "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "files": [
+                    "function.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2162,41 +2356,55 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Debug Component",
+            "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
-            "time": "2017-07-28T15:27:31+00:00"
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.3.6",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "427987eb4eed764c3b6e38d52a0f87989e010676"
+                "reference": "7da8ea2362a283771478c5f7729cfcb43a76b8b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/427987eb4eed764c3b6e38d52a0f87989e010676",
-                "reference": "427987eb4eed764c3b6e38d52a0f87989e010676",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7da8ea2362a283771478c5f7729cfcb43a76b8b7",
+                "reference": "7da8ea2362a283771478c5f7729cfcb43a76b8b7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
@@ -2219,33 +2427,48 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Filesystem Component",
+            "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
-            "time": "2017-07-11T07:17:58+00:00"
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-27T06:33:22+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.6",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4"
+                "reference": "6e5688d69f7cfc4ed4a511e96007e06c2d34ce56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/baea7f66d30854ad32988c11a09d7ffd485810c4",
-                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/6e5688d69f7cfc4ed4a511e96007e06c2d34ce56",
+                "reference": "6e5688d69f7cfc4ed4a511e96007e06c2d34ce56",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
@@ -2268,33 +2491,46 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Finder Component",
+            "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01T21:01:25+00:00"
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-31T17:59:56+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.3.6",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "ff48982d295bcac1fd861f934f041ebc73ae40f0"
+                "reference": "700ff4096e346f54cb628ea650767c8130f1001f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ff48982d295bcac1fd861f934f041ebc73ae40f0",
-                "reference": "ff48982d295bcac1fd861f934f041ebc73ae40f0",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/700ff4096e346f54cb628ea650767c8130f1001f",
+                "reference": "700ff4096e346f54cb628ea650767c8130f1001f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\OptionsResolver\\": ""
@@ -2317,31 +2553,51 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony OptionsResolver Component",
+            "description": "Provides an improved replacement for the array_replace PHP function",
             "homepage": "https://symfony.com",
             "keywords": [
                 "config",
                 "configuration",
                 "options"
             ],
-            "time": "2017-04-12T14:14:56+00:00"
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-08T10:20:21+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -2349,16 +2605,20 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2366,12 +2626,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -2382,24 +2642,209 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.11.0",
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "875e90aeea2777b6f135677f618529449334a612"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
+                "reference": "875e90aeea2777b6f135677f618529449334a612",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -2407,16 +2852,20 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2441,31 +2890,43 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.3.6",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "07432804942b9f6dd7b7377faf9920af5f95d70a"
+                "reference": "13bdb1670c7f510494e04fcb2bfa29af63db9c0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/07432804942b9f6dd7b7377faf9920af5f95d70a",
-                "reference": "07432804942b9f6dd7b7377faf9920af5f95d70a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/13bdb1670c7f510494e04fcb2bfa29af63db9c0d",
+                "reference": "13bdb1670c7f510494e04fcb2bfa29af63db9c0d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=8.2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
@@ -2488,29 +2949,214 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Process Component",
+            "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
-            "time": "2017-07-13T13:05:09+00:00"
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-20T16:43:42+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "name": "symfony/service-contracts",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^2.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-30T20:28:31+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "92bd2bfbba476d4a1838e5e12168bef2fd1e6620"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/92bd2bfbba476d4a1838e5e12168bef2fd1e6620",
+                "reference": "92bd2bfbba476d4a1838e5e12168bef2fd1e6620",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-29T08:40:23+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2530,39 +3176,48 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-20T00:12:19+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.4.0",
+            "name": "webmozart/glob",
+            "version": "4.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "url": "https://github.com/webmozarts/glob.git",
+                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozarts/glob/zipball/3c17f7dec3d9d0e87b575026011f2e75a56ed655",
+                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
-                "symfony/polyfill-ctype": "^1.8"
+                "php": "^7.3 || ^8.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^9.5",
+                "symfony/filesystem": "^5.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
+                    "Webmozart\\Glob\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2575,13 +3230,12 @@
                     "email": "bschussek@gmail.com"
                 }
             ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "description": "A PHP implementation of Ant's glob.",
+            "support": {
+                "issues": "https://github.com/webmozarts/glob/issues",
+                "source": "https://github.com/webmozarts/glob/tree/4.6.0"
+            },
+            "time": "2022-05-24T19:45:58+00:00"
         }
     ],
     "aliases": [],
@@ -2592,10 +3246,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0.0"
+        "php": ">=8.1.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0.0"
-    }
+        "php": "8.2.0"
+    },
+    "plugin-api-version": "2.6.0"
 }

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -1,21 +1,5 @@
 {
-    "php_disable_ini": true,
-    "bootstrap": "vendor/autoload.php",
-    "path": "test/benchmark",
-    "php_config": {
-        "extension": [ "json.so" ]
-    },
-    "outputs": {
-         "benchmarks_file": {
-             "extends": "html",
-             "file": "benchmarks.html",
-             "title": "gfx-php benchmarks"
-         }
-    },
-    "reports": {
-        "my_report": {
-            "extends": "aggregate"
-        }
-    },
-    "time_unit": "microseconds"
+    "$schema":"./vendor/phpbench/phpbench/phpbench.schema.json",
+    "runner.bootstrap": "vendor/autoload.php",
+    "runner.path": "test/benchmark"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,16 @@
-<phpunit bootstrap="test/bootstrap.php"
-timeoutForSmallTests="1"
-timeoutForMediumTests="10"
-timeoutForLargeTests="60"
-verbose="true"
-
->
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="test/bootstrap.php"
+         timeoutForSmallTests="1"
+         timeoutForMediumTests="10"
+         timeoutForLargeTests="60"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true">
+  <coverage/>
   <testsuites>
     <testsuite name="unit">
       <directory>test/unit</directory>
@@ -13,9 +19,9 @@ verbose="true"
       <directory>test/integration</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
+  <source>
+    <include>
       <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
+    </include>
+  </source>
 </phpunit>

--- a/src/Mike42/GfxPhp/AbstractRasterImage.php
+++ b/src/Mike42/GfxPhp/AbstractRasterImage.php
@@ -12,7 +12,7 @@ abstract class AbstractRasterImage implements RasterImage
      *
      * @param int $fill
      */
-    public function rect($startX, $startY, $width, $height, $filled = false, $outline = 1, $fill = 1)
+    public function rect(int $startX, int $startY, int $width, int $height, bool $filled = false, int $outline = 1, int $fill = 1): void
     {
         $this -> horizontalLine($startY, $startX, $startX + $width - 1, $outline);
         $this -> horizontalLine($startY + $height - 1, $startX, $startX + $width - 1, $outline);
@@ -28,21 +28,21 @@ abstract class AbstractRasterImage implements RasterImage
         }
     }
  
-    protected function horizontalLine($y, $startX, $endX, $outline)
+    protected function horizontalLine(int $y, int $startX, int $endX, int $outline): void
     {
         for ($x = $startX; $x <= $endX; $x++) {
             $this -> setPixel($x, $y, $outline);
         }
     }
     
-    protected function verticalLine($x, $startY, $endY, $outline)
+    protected function verticalLine(int $x, int $startY, int $endY, int $outline): void
     {
         for ($y = $startY; $y <= $endY; $y++) {
             $this -> setPixel($x, $y, $outline);
         }
     }
     
-    public function write(string $filename)
+    public function write(string $filename): void
     {
         // Use file extension to decide output codec
         $ext = pathinfo($filename, PATHINFO_EXTENSION);
@@ -83,7 +83,7 @@ abstract class AbstractRasterImage implements RasterImage
         return $ret;
     }
 
-    public function compose(RasterImage $source, int $startX, int $startY, int $destStartX, int $destStartY, int $width, int $height)
+    public function compose(RasterImage $source, int $startX, int $startY, int $destStartX, int $destStartY, int $width, int $height): void
     {
         for ($y = 0; $y < $height; $y++) {
             $srcY = $y + $startY;

--- a/src/Mike42/GfxPhp/AbstractRasterImage.php
+++ b/src/Mike42/GfxPhp/AbstractRasterImage.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp;
 

--- a/src/Mike42/GfxPhp/BlackAndWhiteRasterImage.php
+++ b/src/Mike42/GfxPhp/BlackAndWhiteRasterImage.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp;
 
 /**
@@ -7,30 +9,30 @@ namespace Mike42\GfxPhp;
  */
 class BlackAndWhiteRasterImage extends AbstractRasterImage
 {
-    protected $width;
+    protected int $width;
 
-    protected $bytesPerRow;
+    protected int $bytesPerRow;
 
-    protected $height;
+    protected int $height;
 
-    protected $data;
+    protected array $data;
 
-    public function invert()
+    public function invert(): void
     {
-        array_walk($this -> data, 'self::invertByte');
+        array_walk($this -> data, [$this, 'invertByte']);
     }
 
-    public function clear()
+    public function clear(): void
     {
-        array_walk($this -> data, 'self::clearByte');
+        array_walk($this -> data, [$this, 'clearByte']);
     }
 
-    protected static function invertByte(int &$item, $key)
+    protected static function invertByte(int &$item, $key): void
     {
-        $item = ~ $item;
+        $item = ~$item;
     }
 
-    protected static function clearByte(int &$item, $key)
+    protected static function clearByte(int &$item, $key): void
     {
         $item = 0;
     }
@@ -46,7 +48,7 @@ class BlackAndWhiteRasterImage extends AbstractRasterImage
     }
 
 
-    public function setPixel(int $x, int $y, int $value)
+    public function setPixel(int $x, int $y, int $value): void
     {
         if ($x < 0 || $x >= $this -> width) {
             return;
@@ -78,7 +80,7 @@ class BlackAndWhiteRasterImage extends AbstractRasterImage
         return ($this -> data[$byte] >> (7 - $bit)) & 0x01;
     }
 
-    protected function __construct($width, $height, array $data)
+    protected function __construct(int $width, int $height, array $data)
     {
         $this -> width = $width;
         $this -> height = $height;
@@ -86,7 +88,7 @@ class BlackAndWhiteRasterImage extends AbstractRasterImage
         $this -> bytesPerRow = intdiv($width + 7, 8);
     }
 
-    public static function create($width, $height, array $data = null) : BlackAndWhiteRasterImage
+    public static function create(int $width, int $height, array $data = null) : BlackAndWhiteRasterImage
     {
         $bytesPerRow = intdiv($width + 7, 8);
         $expectedBytes = $bytesPerRow * $height;
@@ -96,7 +98,7 @@ class BlackAndWhiteRasterImage extends AbstractRasterImage
         return new BlackAndWhiteRasterImage($width, $height, $data);
     }
 
-    public function toString()
+    public function toString(): string
     {
         $out = "";
         for ($y = 0; $y < $this -> getHeight(); $y += 2) {
@@ -124,7 +126,7 @@ class BlackAndWhiteRasterImage extends AbstractRasterImage
         return pack("C*", ... $this -> data);
     }
     
-    public function mapColor(int $srcColor, RasterImage $destImage)
+    public function mapColor(int $srcColor, RasterImage $destImage): int
     {
         if ($destImage instanceof BlackAndWhiteRasterImage) {
             return $srcColor;

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpBitfieldDecoder.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpBitfieldDecoder.php
@@ -1,10 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Bmp;
 
 class BmpBitfieldDecoder
 {
-    private $bitfields;
+    private BmpColorBitfield $bitfields;
 
     public function __construct(BmpColorBitfield $bitfields)
     {
@@ -65,7 +66,7 @@ class BmpBitfieldDecoder
         return $outpBytes;
     }
 
-    public function mixChannel(int $value1, int $value2, int $amount)
+    public function mixChannel(int $value1, int $value2, int $amount): int
     {
         $amountMultiplier = $amount / 255.0;
         $result = (($value1 / 255.0) * $amountMultiplier) + (($value2 / 255.0) * (1.0 - $amountMultiplier));

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpColorBitfield.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpColorBitfield.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Bmp;
 
@@ -7,10 +8,10 @@ namespace Mike42\GfxPhp\Codec\Bmp;
  */
 class BmpColorBitfield
 {
-    private $red;
-    private $green;
-    private $blue;
-    private $alpha;
+    private BmpColorMask $red;
+    private BmpColorMask $green;
+    private BmpColorMask $blue;
+    private BmpColorMask $alpha;
 
     public function __construct(BmpColorMask $red, BmpColorMask $green, BmpColorMask $blue, BmpColorMask $alpha)
     {

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpColorBitfield.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpColorBitfield.php
@@ -30,38 +30,38 @@ class BmpColorBitfield
         $this->alpha = $alpha;
     }
 
-    public function getRed()
+    public function getRed(): BmpColorMask
     {
         return $this->red;
     }
 
-    public function getGreen()
+    public function getGreen(): BmpColorMask
     {
         return $this->green;
     }
 
-    public function getBlue()
+    public function getBlue(): BmpColorMask
     {
         return $this->blue;
     }
 
-    public function getAlpha()
+    public function getAlpha(): BmpColorMask
     {
         return $this->alpha;
     }
 
-    public static function fromRgba(int $r, int $g, int $b, int $a)
+    public static function fromRgba(int $r, int $g, int $b, int $a): BmpColorBitfield
     {
         return new BmpColorBitfield(new BmpColorMask($r), new BmpColorMask($g), new BmpColorMask($b), new BmpColorMask($a));
     }
 
-    public static function from16bitDefaults()
+    public static function from16bitDefaults(): BmpColorBitfield
     {
         // If not specified, we use XRRRRRGG GGGBBBBB
         return self::fromRgba(0x7c00, 0x03e0, 0x001f, 0x0000);
     }
 
-    public static function from32bitDefaults()
+    public static function from32bitDefaults(): BmpColorBitfield
     {
         // If not specified, we use XXXXXXXX RRRRRRRR GGGGGGGG BBBBBBBB
         return self::fromRgba(0x00ff0000, 0x0000ff00, 0x000000ff, 0x00000000);

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpColorMask.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpColorMask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Bmp;
 
@@ -41,7 +42,7 @@ class BmpColorMask
         return $this->offset;
     }
 
-    public function getMask()
+    public function getMask(): int
     {
         return $this->mask;
     }

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpColorMask.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpColorMask.php
@@ -5,9 +5,9 @@ namespace Mike42\GfxPhp\Codec\Bmp;
 
 class BmpColorMask
 {
-    private $mask;
-    private $len;
-    private $offset;
+    private int $mask;
+    private int $len;
+    private int $offset;
 
     public function __construct(int $mask)
     {
@@ -32,12 +32,12 @@ class BmpColorMask
         $this->len = $len;
     }
 
-    public function getLen()
+    public function getLen(): int
     {
         return $this->len;
     }
 
-    public function getOffset()
+    public function getOffset(): int
     {
         return $this->offset;
     }
@@ -47,13 +47,13 @@ class BmpColorMask
         return $this->mask;
     }
 
-    public function getValue(int $input)
+    public function getValue(int $input): int
     {
         // Read value 0 to max value
         return ($input & $this -> mask) >> $this -> offset;
     }
 
-    public function getMaxValue()
+    public function getMaxValue(): int
     {
         // Max value for size of this channel
         return (2 ** $this->len)- 1;
@@ -62,7 +62,7 @@ class BmpColorMask
     /**
      * Mask out a value for this channel, and return its value in a 0-255 range
      */
-    public function getNormalisedValue(int $input)
+    public function getNormalisedValue(int $input): int
     {
         // Get raw value, range depends on mask length
         $rawValue = ($input & ($this -> mask)) >> ($this -> offset);

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec\Bmp;
 
 use Exception;

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpFile.php
@@ -14,10 +14,10 @@ class BmpFile
 {
     const BMP_SIGNATURE = "BM";
 
-    private $fileHeader;
-    private $infoHeader;
-    private $palette;
-    private $uncompressedData;
+    private BmpFileHeader $fileHeader;
+    private BmpInfoHeader $infoHeader;
+    private array $palette;
+    private array $uncompressedData;
 
     public function __construct(BmpFileHeader $fileHeader, BmpInfoHeader $infoHeader, array $data, array $palette)
     {
@@ -189,7 +189,7 @@ class BmpFile
         return new BmpFile($fileHeader, $infoHeader, $dataArray, $colorTable);
     }
 
-    private static function isOs21XBitmap(BmpFileHeader $fileHeader, BmpInfoHeader $infoHeader, int $colorCount)
+    private static function isOs21XBitmap(BmpFileHeader $fileHeader, BmpInfoHeader $infoHeader, int $colorCount): bool
     {
         // OS/2 1.x bitmaps use 24 bits per entry in the color palette, rather than 32, but share the same 12-byte
         // header as original Windows bitmaps. If the header size, color count and offset to the bitmap data are
@@ -246,7 +246,7 @@ class BmpFile
         throw new Exception("Unknown bit depth " . $this -> infoHeader -> bpp);
     }
 
-    public static function transformRevString(&$item, $key)
+    public static function transformRevString(&$item, $key): void
     {
         // Convert RGB to BGR
         $item = strrev($item);

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpFileHeader.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpFileHeader.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Bmp;
 
@@ -10,8 +10,9 @@ class BmpFileHeader
 {
     const FILE_HEADER_SIZE = 14;
 
-    public $offset;
-    public $size;
+    public int $offset;
+    public int $size;
+    private string $fileType;
 
     public function __construct(string $fileType, int $size, int $offset)
     {

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec\Bmp;
 
 use Exception;

--- a/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/BmpInfoHeader.php
@@ -29,27 +29,27 @@ class BmpInfoHeader
     const B1_CMYKRLE8 = 12;
     const B1_CMYKRLE4 = 13;
 
-    public $bpp;
-    public $colors;
-    public $compressedSize;
-    public $compression;
-    public $headerSize;
-    public $height;
-    public $horizontalRes;
-    public $importantColors;
-    public $planes;
-    public $verticalRes;
-    public $width;
-    public $redMask;
-    public $greenMask;
-    public $blueMask;
-    public $alphaMask;
-    public $csType;
-    public $endpoint;
-    public $gamma;
-    public $intent;
-    public $profileData;
-    public $profileSize;
+    public int $bpp;
+    public int $colors;
+    public int $compressedSize;
+    public int $compression;
+    public int $headerSize;
+    public int $height;
+    public int $horizontalRes;
+    public int $importantColors;
+    public int $planes;
+    public int $verticalRes;
+    public int $width;
+    public int $redMask;
+    public int $greenMask;
+    public int $blueMask;
+    public int $alphaMask;
+    public int $csType;
+    public array $endpoint;
+    public array $gamma;
+    public int $intent;
+    public int $profileData;
+    public int $profileSize;
 
     public function __construct(
         int $headerSize,
@@ -333,7 +333,7 @@ class BmpInfoHeader
         );
     }
 
-    private static function readOs22xBitmapHeader(int $size, DataInputStream $data)
+    private static function readOs22xBitmapHeader(int $size, DataInputStream $data): BmpInfoHeader
     {
         $coreData = $data -> read(self::OS22XBITMAPHEADER_MIN_SIZE - 4);
         $coreFields = unpack("Vwidth/Vheight/vplanes/vbpp", $coreData);

--- a/src/Mike42/GfxPhp/Codec/Bmp/Rle4Decoder.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/Rle4Decoder.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Bmp;
 

--- a/src/Mike42/GfxPhp/Codec/Bmp/Rle8Decoder.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/Rle8Decoder.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec\Bmp;
 
 use Exception;

--- a/src/Mike42/GfxPhp/Codec/Bmp/RleCanvas.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/RleCanvas.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Bmp;
 

--- a/src/Mike42/GfxPhp/Codec/Bmp/RleCanvas.php
+++ b/src/Mike42/GfxPhp/Codec/Bmp/RleCanvas.php
@@ -11,12 +11,12 @@ use Exception;
  */
 class RleCanvas
 {
-    private $buffer;
-    private $cursorX;
-    private $cursorY;
-    private $width;
-    private $height;
-    private $complete;
+    private array $buffer;
+    private int $cursorX;
+    private int $cursorY;
+    private int $width;
+    private int $height;
+    private bool $complete;
 
     public function __construct(int $width, int $height)
     {
@@ -33,24 +33,24 @@ class RleCanvas
         $this->buffer = $tmp;
     }
 
-    public function delta(int $deltaX, int $deltaY)
+    public function delta(int $deltaX, int $deltaY): void
     {
         $this -> cursorX += $deltaX;
         $this -> cursorY += $deltaY;
     }
 
-    public function endOfLine()
+    public function endOfLine(): void
     {
         $this -> cursorY++;
         $this -> cursorX = 0;
     }
 
-    public function endOfBitmap()
+    public function endOfBitmap(): void
     {
         $this -> complete = true;
     }
 
-    public function set(int $val)
+    public function set(int $val): void
     {
         // Range check when we attempt to write the pixel.
         if ($this -> cursorY < 0 || $this -> cursorY >= $this -> height) {
@@ -67,21 +67,21 @@ class RleCanvas
         $this -> cursorX++;
     }
 
-    public function absolute(array $values)
+    public function absolute(array $values): void
     {
         for ($i = 0; $i < count($values); $i++) {
             $this -> set($values[$i]);
         }
     }
 
-    public function repeat(int $val, int $times)
+    public function repeat(int $val, int $times): void
     {
         for ($j = 0; $j < $times; $j++) {
             $this -> set($val);
         }
     }
 
-    public function getContents()
+    public function getContents(): array
     {
         return $this -> buffer;
     }

--- a/src/Mike42/GfxPhp/Codec/BmpCodec.php
+++ b/src/Mike42/GfxPhp/Codec/BmpCodec.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec;
 

--- a/src/Mike42/GfxPhp/Codec/BmpCodec.php
+++ b/src/Mike42/GfxPhp/Codec/BmpCodec.php
@@ -11,7 +11,7 @@ use Mike42\GfxPhp\RgbRasterImage;
 
 class BmpCodec implements ImageEncoder, ImageDecoder
 {
-    protected static $instance = null;
+    protected static ?BmpCodec $instance = null;
     const INFO_HEADER_SIZE = 40;
     const FILE_HEADER_SIZE = 14;
 
@@ -64,7 +64,7 @@ class BmpCodec implements ImageEncoder, ImageDecoder
         return $header . $infoHeader . $colorTable . $pixelData;
     }
 
-    protected function transformRevString(&$item, $key)
+    protected function transformRevString(&$item, $key): void
     {
         // Convert RGB to BGR
         $item = strrev($item);
@@ -95,7 +95,7 @@ class BmpCodec implements ImageEncoder, ImageDecoder
         return ["bmp", "dib"];
     }
 
-    public static function getInstance()
+    public static function getInstance(): BmpCodec
     {
         if (self::$instance === null) {
             self::$instance = new BmpCodec();

--- a/src/Mike42/GfxPhp/Codec/Common/DataBlobInputStream.php
+++ b/src/Mike42/GfxPhp/Codec/Common/DataBlobInputStream.php
@@ -14,19 +14,19 @@ class DataBlobInputStream implements DataInputStream
         $this -> offset = 0;
     }
 
-    public function read(int $bytes)
+    public function read(int $bytes): string
     {
         $chunk = $this -> peek($bytes);
         $this -> advance($bytes);
         return $chunk;
     }
 
-    public function advance(int $bytes)
+    public function advance(int $bytes): void
     {
         $this -> offset += $bytes;
     }
 
-    public function peek(int $bytes)
+    public function peek(int $bytes): string
     {
         $chunk = substr($this -> data, $this -> offset, $bytes);
         if ($chunk === false) {
@@ -39,17 +39,17 @@ class DataBlobInputStream implements DataInputStream
         return $chunk;
     }
 
-    public function isEof()
+    public function isEof(): bool
     {
         return $this -> offset >= strlen($this -> data);
     }
  
-    public static function fromBlob(string $blob)
+    public static function fromBlob(string $blob): DataBlobInputStream
     {
         return new DataBlobInputStream($blob);
     }
     
-    public static function fromFilename(string $filename)
+    public static function fromFilename(string $filename): DataBlobInputStream
     {
         $blob = file_get_contents($filename);
         if ($blob === false) {

--- a/src/Mike42/GfxPhp/Codec/Common/DataBlobInputStream.php
+++ b/src/Mike42/GfxPhp/Codec/Common/DataBlobInputStream.php
@@ -1,9 +1,13 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Common;
 
 class DataBlobInputStream implements DataInputStream
 {
+    private string $data;
+    private int $offset;
+
     public function __construct(string $data)
     {
         $this -> data = $data;

--- a/src/Mike42/GfxPhp/Codec/Common/DataInputStream.php
+++ b/src/Mike42/GfxPhp/Codec/Common/DataInputStream.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Common;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifApplicationExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifApplicationExt.php
@@ -7,9 +7,9 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 
 class GifApplicationExt
 {
-    private $appIdentifer;
-    private $appAuthCode;
-    private $data;
+    private string $appIdentifer;
+    private string $appAuthCode;
+    private array $data;
 
     public function __construct(string $appIdentifer, string $appAuthCode, array $data)
     {

--- a/src/Mike42/GfxPhp/Codec/Gif/GifApplicationExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifApplicationExt.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifColorTable.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifColorTable.php
@@ -3,16 +3,18 @@ declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 
+use Mike42\GfxPhp\Codec\Common\DataInputStream;
+
 class GifColorTable
 {
-    private $palette;
+    private array $palette;
 
     public function __construct(array $palette)
     {
         $this -> palette = $palette;
     }
 
-    public static function fromBin(\Mike42\GfxPhp\Codec\Common\DataInputStream $in, int $globalColorTableSize)
+    public static function fromBin(DataInputStream $in, int $globalColorTableSize): GifColorTable
     {
         $tableData = $in -> read($globalColorTableSize * 3);
         $paletteArr = array_values(unpack("C*", $tableData));

--- a/src/Mike42/GfxPhp/Codec/Gif/GifColorTable.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifColorTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifCommentExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifCommentExt.php
@@ -7,7 +7,7 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 
 class GifCommentExt
 {
-    private $data;
+    private array $data;
 
     public function getData(): array
     {
@@ -19,7 +19,7 @@ class GifCommentExt
         $this -> data = $data;
     }
 
-    public static function fromBin(DataInputStream $in)
+    public static function fromBin(DataInputStream $in): GifCommentExt
     {
         $extIntroducer = $in->read(1);
         $extLabel = $in->read(1);

--- a/src/Mike42/GfxPhp/Codec/Gif/GifCommentExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifCommentExt.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifData.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifData.php
@@ -14,9 +14,9 @@ class GifData
     const GIF_EXTENSION_APPLICATION="\xFF";
     const GIF_EXTENSION_COMMENT="\xFE";
 
-    private $graphicsBlock;
-    private $specialPurposeBlock;
-    private $unrecognisedBlock;
+    private ?GifGraphicsBlock $graphicsBlock;
+    private ?GifSpecialPurposeBlock $specialPurposeBlock;
+    private ?GifUnknownExt $unrecognisedBlock;
 
     public function __construct(GifGraphicsBlock $graphicsBlock = null, GifSpecialPurposeBlock $specialPurposeBlock = null, GifUnknownExt $unrecognisedBlock = null)
     {
@@ -25,17 +25,17 @@ class GifData
         $this->unrecognisedBlock = $unrecognisedBlock;
     }
 
-    public function getUnrecognisedBlock()
+    public function getUnrecognisedBlock(): ?GifUnknownExt
     {
         return $this->unrecognisedBlock;
     }
 
-    public function getSpecialPurposeBlock()
+    public function getSpecialPurposeBlock(): ?GifSpecialPurposeBlock
     {
         return $this->specialPurposeBlock;
     }
 
-    public function getGraphicsBlock()
+    public function getGraphicsBlock(): ?GifGraphicsBlock
     {
         return $this->graphicsBlock;
     }

--- a/src/Mike42/GfxPhp/Codec/Gif/GifData.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifData.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifDataStream.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifDataStream.php
@@ -13,10 +13,10 @@ class GifDataStream
     const GIF89_SIGNATURE="GIF89a";
     const GIF_TRAILER="\x3B";
 
-    private $header;
-    private $logicalScreen;
-    private $data;
-    private $trailer;
+    private string $header;
+    private GifLogicalScreen $logicalScreen;
+    private array $data;
+    private string $trailer;
 
     private function __construct(string $header, GifLogicalScreen $logicalScreen, array $data, string $trailer)
     {

--- a/src/Mike42/GfxPhp/Codec/Gif/GifDataStream.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifDataStream.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec\Gif;
 
 use Mike42\GfxPhp\Codec\Common\DataInputStream;

--- a/src/Mike42/GfxPhp/Codec/Gif/GifGraphicControlExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifGraphicControlExt.php
@@ -7,11 +7,11 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 
 class GifGraphicControlExt
 {
-    private $disposalMethod;
-    private $hasUserInputFlag;
-    private $hasTransparentColor;
-    private $delayTime;
-    private $transparentColorIndex;
+    private int $disposalMethod;
+    private bool $hasUserInputFlag;
+    private bool $hasTransparentColor;
+    private int $delayTime;
+    private int $transparentColorIndex;
 
     public function __construct(int $disposalMethod, bool $hasUserInputFlag, bool $hasTransparentColor, int $delayTime, int $transparentColorIndex)
     {

--- a/src/Mike42/GfxPhp/Codec/Gif/GifGraphicControlExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifGraphicControlExt.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifGraphicsBlock.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifGraphicsBlock.php
@@ -7,9 +7,9 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 
 class GifGraphicsBlock
 {
-    private $graphicControlExt;
-    private $tableBasedImage;
-    private $plaintextExt;
+    private ?GifGraphicControlExt $graphicControlExt;
+    private ?GifTableBasedImage $tableBasedImage;
+    private ?GifPlaintextExt $plaintextExt;
 
     public function __construct(GifGraphicControlExt $graphicControlExt = null, GifTableBasedImage $tableBasedImage = null, GifPlaintextExt $plaintextExt = null)
     {
@@ -18,17 +18,17 @@ class GifGraphicsBlock
         $this->plaintextExt = $plaintextExt;
     }
 
-    public function getGraphicControlExt()
+    public function getGraphicControlExt(): ?GifGraphicControlExt
     {
         return $this->graphicControlExt;
     }
 
-    public function getTableBasedImage()
+    public function getTableBasedImage(): ?GifTableBasedImage
     {
         return $this->tableBasedImage;
     }
 
-    public function getPlaintextExt()
+    public function getPlaintextExt(): ?GifPlaintextExt
     {
         return $this->plaintextExt;
     }

--- a/src/Mike42/GfxPhp/Codec/Gif/GifGraphicsBlock.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifGraphicsBlock.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifImageDescriptor.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifImageDescriptor.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifImageDescriptor.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifImageDescriptor.php
@@ -8,14 +8,14 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 class GifImageDescriptor
 {
 
-    private $left;
-    private $top;
-    private $width;
-    private $height;
-    private $hasLocalColorTable;
-    private $isInterlaced;
-    private $hasSortedLocalColorTable;
-    private $localColorTableSize;
+    private int $left;
+    private int $top;
+    private int $width;
+    private int $height;
+    private bool $hasLocalColorTable;
+    private bool $isInterlaced;
+    private bool $hasSortedLocalColorTable;
+    private int $localColorTableSize;
 
     public function __construct(int $left, int $top, int $width, int $height, bool $hasLocalColorTable, bool $isInterlaced, bool $hasSortedLocalColorTable, int $localColorTableSize)
     {

--- a/src/Mike42/GfxPhp/Codec/Gif/GifLogicalScreen.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifLogicalScreen.php
@@ -8,8 +8,8 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 class GifLogicalScreen
 {
 
-    private $logicalScreenDescriptor;
-    private $globalColorTable;
+    private GifLogicalScreenDescriptor $logicalScreenDescriptor;
+    private ?GifColorTable $globalColorTable;
 
     public function __construct(GifLogicalScreenDescriptor $logicalScreenDescriptor, GifColorTable $globalColorTable = null)
     {

--- a/src/Mike42/GfxPhp/Codec/Gif/GifLogicalScreen.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifLogicalScreen.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifLogicalScreenDescriptor.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifLogicalScreenDescriptor.php
@@ -7,14 +7,14 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 
 class GifLogicalScreenDescriptor
 {
-    private $width;
-    private $height;
-    private $hasGlobalColorTable;
-    private $colorResolution;
-    private $hasSortedGlobalColorTable;
-    private $globalColorTableSize;
-    private $backgroundColorIndex;
-    private $pixelAspectRatio;
+    private int $width;
+    private int $height;
+    private bool $hasGlobalColorTable;
+    private int $colorResolution;
+    private bool $hasSortedGlobalColorTable;
+    private int $globalColorTableSize;
+    private int $backgroundColorIndex;
+    private int $pixelAspectRatio;
 
     public function __construct(int $width, int $height, bool $hasGlobalColorTable, int $colorResolution, bool $hasSortedGlobalColorTable, int $globalColorTableSize, int $backgroundColorIndex, int $pixelAspectRatio)
     {

--- a/src/Mike42/GfxPhp/Codec/Gif/GifLogicalScreenDescriptor.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifLogicalScreenDescriptor.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifPlaintextExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifPlaintextExt.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifPlaintextExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifPlaintextExt.php
@@ -8,7 +8,7 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 class GifPlaintextExt
 {
 
-    private $header;
+    private string $header;
 
     public function getHeader(): string
     {
@@ -19,7 +19,7 @@ class GifPlaintextExt
     {
         return $this->data;
     }
-    private $data;
+    private array $data;
 
     public function __construct(string $header, array $data)
     {

--- a/src/Mike42/GfxPhp/Codec/Gif/GifSpecialPurposeBlock.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifSpecialPurposeBlock.php
@@ -6,8 +6,8 @@ namespace Mike42\GfxPhp\Codec\Gif;
 class GifSpecialPurposeBlock
 {
 
-    private $applicationExt;
-    private $commentExt;
+    private ?GifApplicationExt $applicationExt;
+    private ?GifCommentExt $commentExt;
 
     public function __construct(GifApplicationExt $applicationExt = null, GifCommentExt $commentExt = null)
     {
@@ -15,12 +15,12 @@ class GifSpecialPurposeBlock
         $this->commentExt = $commentExt;
     }
 
-    public function getApplicationExt()
+    public function getApplicationExt(): ?GifApplicationExt
     {
         return $this->applicationExt;
     }
 
-    public function getCommentExt()
+    public function getCommentExt(): ?GifCommentExt
     {
         return $this->commentExt;
     }

--- a/src/Mike42/GfxPhp/Codec/Gif/GifSpecialPurposeBlock.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifSpecialPurposeBlock.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifTableBasedImage.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifTableBasedImage.php
@@ -7,10 +7,10 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 
 class GifTableBasedImage
 {
-    private $imageDescriptor;
-    private $lzqMinSize;
-    private $dataSubBlocks;
-    private $localColorTable;
+    private GifImageDescriptor $imageDescriptor;
+    private int $lzqMinSize;
+    private array $dataSubBlocks;
+    private ?GifColorTable $localColorTable;
 
     public function getImageDescriptor(): GifImageDescriptor
     {
@@ -27,14 +27,13 @@ class GifTableBasedImage
         return $this->dataSubBlocks;
     }
 
-    public function getLocalColorTable()
+    public function getLocalColorTable(): ?GifColorTable
     {
         return $this->localColorTable;
     }
 
     public function __construct(GifImageDescriptor $imageDescriptor, int $lzqMinSize, array $dataSubBlocks, GifColorTable $localColorTable = null)
     {
-
         $this->imageDescriptor = $imageDescriptor;
         $this->lzqMinSize = $lzqMinSize;
         $this->dataSubBlocks = $dataSubBlocks;

--- a/src/Mike42/GfxPhp/Codec/Gif/GifTableBasedImage.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifTableBasedImage.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/Gif/GifUnknownExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifUnknownExt.php
@@ -7,9 +7,9 @@ use Mike42\GfxPhp\Codec\Common\DataInputStream;
 
 class GifUnknownExt
 {
-    private $label;
-    private $header;
-    private $data;
+    private string $label;
+    private string $header;
+    private array $data;
 
     public function __construct(string $label, string $header, array $data)
     {
@@ -34,7 +34,7 @@ class GifUnknownExt
         return $this->data;
     }
 
-    public static function fromBin(DataInputStream $in)
+    public static function fromBin(DataInputStream $in): GifUnknownExt
     {
         $introducer = $in->read(1);
         if ($introducer != GifData::GIF_EXTENSION) {

--- a/src/Mike42/GfxPhp/Codec/Gif/GifUnknownExt.php
+++ b/src/Mike42/GfxPhp/Codec/Gif/GifUnknownExt.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec\Gif;
 

--- a/src/Mike42/GfxPhp/Codec/GifCodec.php
+++ b/src/Mike42/GfxPhp/Codec/GifCodec.php
@@ -11,7 +11,7 @@ use Mike42\GfxPhp\IndexedRasterImage;
 
 class GifCodec implements ImageEncoder, ImageDecoder
 {
-    protected static $instance = null;
+    protected static ?GifCodec $instance = null;
 
     public function encode(RasterImage $image, string $format): string
     {
@@ -107,7 +107,7 @@ class GifCodec implements ImageEncoder, ImageDecoder
         return ["gif"];
     }
 
-    public static function getInstance()
+    public static function getInstance(): GifCodec
     {
         if (self::$instance === null) {
             self::$instance = new GifCodec();

--- a/src/Mike42/GfxPhp/Codec/GifCodec.php
+++ b/src/Mike42/GfxPhp/Codec/GifCodec.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec;
 
 use Mike42\GfxPhp\Codec\Common\DataBlobInputStream;

--- a/src/Mike42/GfxPhp/Codec/ImageCodec.php
+++ b/src/Mike42/GfxPhp/Codec/ImageCodec.php
@@ -5,11 +5,11 @@ namespace Mike42\GfxPhp\Codec;
 
 class ImageCodec
 {
-    protected static $instance = null;
+    protected static ?ImageCodec $instance = null;
 
-    protected $encoders;
+    protected array $encoders;
 
-    protected $decoders;
+    protected array $decoders;
 
     public function __construct(array $encoders, array $decoders)
     {

--- a/src/Mike42/GfxPhp/Codec/ImageCodec.php
+++ b/src/Mike42/GfxPhp/Codec/ImageCodec.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec;
 
 class ImageCodec

--- a/src/Mike42/GfxPhp/Codec/ImageDecoder.php
+++ b/src/Mike42/GfxPhp/Codec/ImageDecoder.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec;
 
 use Mike42\GfxPhp\RasterImage;

--- a/src/Mike42/GfxPhp/Codec/ImageEncoder.php
+++ b/src/Mike42/GfxPhp/Codec/ImageEncoder.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec;
 
 use Mike42\GfxPhp\RasterImage;

--- a/src/Mike42/GfxPhp/Codec/Png/FilterDecoder.php
+++ b/src/Mike42/GfxPhp/Codec/Png/FilterDecoder.php
@@ -8,7 +8,7 @@ class FilterDecoder
     /*
      * Unfilter entire image, or a pass of an interlaced image.
      */
-    public function unfilterImage(string $binData, int $scanlineBytes, int $channels, int $bitDepth)
+    public function unfilterImage(string $binData, int $scanlineBytes, int $channels, int $bitDepth): array
     {
         // Extract filtered data
         $scanlinesWithFiltering = str_split($binData, $scanlineBytes + 1);
@@ -34,7 +34,7 @@ class FilterDecoder
     /**
      * Unfilter an individual scanline
      */
-    public function unfilterScanline(array $currentFiltered, array $prior, int $filterType, int $bpp)
+    public function unfilterScanline(array $currentFiltered, array $prior, int $filterType, int $bpp): array
     {
         $lw = count($currentFiltered);
         if ($filterType === 0) {
@@ -77,7 +77,7 @@ class FilterDecoder
         throw new \Exception("Filter type $filterType not valid");
     }
 
-    private function paethPredictor(int $a, int $b, int $c)
+    private function paethPredictor(int $a, int $b, int $c): int
     {
         // Nearest-neighbor, based on pseudocode from the PNG spec.
         $p = $a + $b - $c;

--- a/src/Mike42/GfxPhp/Codec/Png/FilterDecoder.php
+++ b/src/Mike42/GfxPhp/Codec/Png/FilterDecoder.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec\Png;
 
 class FilterDecoder

--- a/src/Mike42/GfxPhp/Codec/Png/InterlaceDecoder.php
+++ b/src/Mike42/GfxPhp/Codec/Png/InterlaceDecoder.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec\Png;
 
 class InterlaceDecoder

--- a/src/Mike42/GfxPhp/Codec/Png/InterlaceDecoder.php
+++ b/src/Mike42/GfxPhp/Codec/Png/InterlaceDecoder.php
@@ -5,14 +5,14 @@ namespace Mike42\GfxPhp\Codec\Png;
 
 class InterlaceDecoder
 {
-    private $filterDecoder;
+    private FilterDecoder $filterDecoder;
     
     public function __construct(FilterDecoder $filterDecoder)
     {
         $this -> filterDecoder = $filterDecoder;
     }
     
-    public function decode(PngHeader $header, string $binData)
+    public function decode(PngHeader $header, string $binData): array
     {
         if ($header -> getInterlace() === PngHeader::INTERLACE_NONE) {
             // No interlacing!
@@ -25,7 +25,7 @@ class InterlaceDecoder
         return $imageData;
     }
     
-    private function decodeAdam7Interlace(PngHeader $header, string $binData)
+    private function decodeAdam7Interlace(PngHeader $header, string $binData): array
     {
         $bitDepth = $header -> getBitDepth();
         $width = $header -> getWidth();
@@ -140,7 +140,7 @@ class InterlaceDecoder
         return $imageData;
     }
     
-    private function decodeNoInterlace(PngHeader $header, string $binData)
+    private function decodeNoInterlace(PngHeader $header, string $binData): array
     {
         $bitDepth = $header -> getBitDepth();
         $width = $header -> getWidth();

--- a/src/Mike42/GfxPhp/Codec/Png/PngChunk.php
+++ b/src/Mike42/GfxPhp/Codec/Png/PngChunk.php
@@ -1,13 +1,15 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec\Png;
 
 use Mike42\GfxPhp\Codec\Common\DataInputStream;
 
 class PngChunk
 {
-    private $type;
-    private $data;
-    private $crc;
+    private string $type;
+    private string $data;
+    private int $crc;
     
     public function __construct(string $type, string $data)
     {
@@ -19,7 +21,7 @@ class PngChunk
         $this -> crc = crc32($type . $data);
     }
     
-    public function toBin()
+    public function toBin(): string
     {
         $len = strlen($this -> data);
         $lenData = pack("N", $len);
@@ -28,22 +30,22 @@ class PngChunk
         return $lenData . $bodyData . $crcData;
     }
     
-    public function getCrc()
+    public function getCrc(): int
     {
         return $this -> crc;
     }
     
-    public function getType()
+    public function getType(): string
     {
         return $this -> type;
     }
     
-    public function getData()
+    public function getData(): string
     {
         return $this -> data;
     }
     
-    public static function isValidChunkName(string $name)
+    public static function isValidChunkName(string $name): bool
     {
         if (array_search($name, ["IHDR", "IDAT", "PLTE", "IEND"], true) !== false) {
             // Critical chunks defined as of PNG 1.2
@@ -55,7 +57,7 @@ class PngChunk
         return false;
     }
     
-    public static function fromBin(DataInputStream $in)
+    public static function fromBin(DataInputStream $in): ?PngChunk
     {
         if ($in -> isEof()) {
             return null;
@@ -79,7 +81,7 @@ class PngChunk
         return $chunk;
     }
     
-    public function toString()
+    public function toString(): string
     {
         return $this -> type . " chunk";
     }

--- a/src/Mike42/GfxPhp/Codec/Png/PngHeader.php
+++ b/src/Mike42/GfxPhp/Codec/Png/PngHeader.php
@@ -1,7 +1,7 @@
 <?php
-namespace Mike42\GfxPhp\Codec\Png;
+declare(strict_types=1);
 
-use Mike42\GfxPhp\Codec\Png\PngHeader;
+namespace Mike42\GfxPhp\Codec\Png;
 
 class PngHeader
 {
@@ -17,14 +17,14 @@ class PngHeader
     const INTERLACE_NONE = 0;
     const INTERLACE_ADAM7 = 1;
 
-    private $width;
-    private $height;
-    private $bitDepth;
-    private $colorType;
-    private $compression;
-    private $filter;
-    private $interlace;
-    
+    private int $width;
+    private int $height;
+    private int $bitDepth;
+    private int $colorType;
+    private int $compression;
+    private int $filter;
+    private int $interlace;
+
     public function __construct(int $width, int $height, int $bitDepth, int $colorType, int $compression, int $filter, int $interlace)
     {
         // Image dimensions
@@ -72,7 +72,7 @@ class PngHeader
                 $this -> interlace = $interlace;
     }
     
-    public static function fromChunk(PngChunk $chunk)
+    public static function fromChunk(PngChunk $chunk): PngHeader
     {
         $chunkData = $chunk -> getData();
         $chunkLen = strlen($chunkData);
@@ -102,37 +102,37 @@ class PngHeader
         $this -> colorType === PngHeader::COLOR_TYPE_RGBA;
     }
     
-    public function requiresPalette()
+    public function requiresPalette(): bool
     {
         return $this -> colorType === PngHeader::COLOR_TYPE_INDEXED;
     }
     
-    public function getWidth()
+    public function getWidth(): int
     {
         return $this -> width;
     }
     
-    public function getHeight()
+    public function getHeight(): int
     {
         return $this -> height;
     }
     
-    public function getBitDepth()
+    public function getBitDepth(): int
     {
         return $this -> bitDepth;
     }
     
-    public function getColorType()
+    public function getColorType(): int
     {
         return $this -> colorType;
     }
-    
-    public function getCompresssion()
+
+    public function getCompression(): int
     {
-        return $this -> compresssion;
+        return $this -> compression;
     }
-    
-    public function getChannels()
+
+    public function getChannels(): int
     {
         // Return number of channels
         $channelLookup = [
@@ -145,12 +145,12 @@ class PngHeader
         return $channelLookup[$this -> getColorType()];
     }
     
-    public function getFilter()
+    public function getFilter(): int
     {
         return $this -> filter;
     }
     
-    public function getInterlace()
+    public function getInterlace(): int
     {
         return $this -> interlace;
     }

--- a/src/Mike42/GfxPhp/Codec/Png/PngHeader.php
+++ b/src/Mike42/GfxPhp/Codec/Png/PngHeader.php
@@ -85,7 +85,7 @@ class PngHeader
         return new PngHeader($dataItems['width'], $dataItems['height'], $dataItems['bitDepth'], $dataItems['colorType'], $dataItems['compression'], $dataItems['filter'], $dataItems['interlace']);
     }
     
-    public function toString()
+    public function toString(): string
     {
         return "Image dimensions " . $this -> width . " x " . $this -> height .
         ", bitDepth " . $this -> bitDepth .
@@ -95,7 +95,7 @@ class PngHeader
         ", interlace " . $this -> interlace;
     }
     
-    public function allowsPalette()
+    public function allowsPalette(): bool
     {
         return $this -> requiresPalette() ||
         $this -> colorType === PngHeader::COLOR_TYPE_RGB ||

--- a/src/Mike42/GfxPhp/Codec/Png/PngImage.php
+++ b/src/Mike42/GfxPhp/Codec/Png/PngImage.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec\Png;
 
 use Mike42\GfxPhp\BlackAndWhiteRasterImage;
@@ -279,21 +281,21 @@ class PngImage
     /**
      * We'll use this to mix with a background color.
      */
-    private function alphaMix(array $data, $chunkSize)
+    private function alphaMix(array $data, $chunkSize): array
     {
         // Will need to change to "alphaMixPixel" to [$this, "alphaMixPixel"] once we are in a class.
         $noAlphaPixels = array_map([$this, "alphaMixPixel"], array_chunk($data, $chunkSize, false));
         return array_merge(...$noAlphaPixels);
     }
     
-    private function alphaMixPixel(array $channels)
+    private function alphaMixPixel(array $channels): array
     {
         // Mix alpha to white
         $maxLevel = 2 ** $this -> header -> getBitDepth() - 1;
         $backGround = $maxLevel;
         $alpha = array_pop($channels) / $maxLevel;
         foreach ($channels as $id => $channel) {
-            $pixels[$id] = ($maxLevel - ($maxLevel - $channel) * $alpha);
+            $pixels[$id] = (int)($maxLevel - ($maxLevel - $channel) * $alpha);
         }
         return $pixels;
     }

--- a/src/Mike42/GfxPhp/Codec/Png/PngImage.php
+++ b/src/Mike42/GfxPhp/Codec/Png/PngImage.php
@@ -14,9 +14,9 @@ class PngImage
 {
     const PNG_SIGNATURE="\x89\x50\x4E\x47\x0D\x0A\x1A\x0A";
 
-    private $header;
-    private $imageData;
-    private $chunkPalette;
+    private PngHeader $header;
+    private array $imageData;
+    private ?PngChunk $chunkPalette;
     
     private function __construct(PngHeader $header, array $imageData, PngChunk $chunkPalette = null)
     {
@@ -213,7 +213,7 @@ class PngImage
      * Takes 8-bit samples, and produces eight times as many 1-bit samples,
      * dropping padding bits along the way.
      */
-    public static function expandBytes1Bpp(array $in, int $width)
+    public static function expandBytes1Bpp(array $in, int $width): array
     {
         $res =  [];
         $scanlineBytes = intdiv($width + 7, 8);
@@ -233,7 +233,7 @@ class PngImage
      * Takes 8-bit samples, and produces four times as many 2-bit samples,
      * dropping padding bits along the way.
      */
-    public static function expandBytes2Bpp(array $in, int $width)
+    public static function expandBytes2Bpp(array $in, int $width): array
     {
         $res =  [];
         $scanlineBytes = intdiv($width + 3, 4);
@@ -253,7 +253,7 @@ class PngImage
      * Takes 8-bit samples, and produces twice as many 4-bit samples,
      * dropping padding bits along the way.
      */
-    public static function expandBytes4Bpp(array $in, int $width)
+    public static function expandBytes4Bpp(array $in, int $width): array
     {
         $scanlineBytes = intdiv($width + 1, 2);
         $scanlines = array_chunk($in, $scanlineBytes);
@@ -272,7 +272,7 @@ class PngImage
     /**
      * Takes 8-bit samples, and produces half as many 16-bit samples.
      */
-    public static function combineBytes16Bpp(array $in)
+    public static function combineBytes16Bpp(array $in): array
     {
         $data = array_values(unpack("n*", pack("C*", ...$in)));
         return $data;

--- a/src/Mike42/GfxPhp/Codec/PngCodec.php
+++ b/src/Mike42/GfxPhp/Codec/PngCodec.php
@@ -10,7 +10,7 @@ use Mike42\GfxPhp\Codec\Png\PngImage;
 
 class PngCodec implements ImageEncoder, ImageDecoder
 {
-    protected static $instance = null;
+    protected static ?PngCodec $instance = null;
 
     public function encode(RasterImage $image, string $format): string
     {
@@ -36,7 +36,7 @@ class PngCodec implements ImageEncoder, ImageDecoder
         return $png -> toRasterImage();
     }
     
-    public function encodeRgb(RgbRasterImage $image)
+    public function encodeRgb(RgbRasterImage $image): string
     {
         // PNG signature
         $signature = PngImage::PNG_SIGNATURE;
@@ -53,7 +53,7 @@ class PngCodec implements ImageEncoder, ImageDecoder
         return $signature . $ihdr . $idat . $iend;
     }
 
-    protected function chunk(string $type, string $data = '')
+    protected function chunk(string $type, string $data = ''): string
     {
         $len = strlen($data);
         $lenData = pack("N", $len);
@@ -72,7 +72,7 @@ class PngCodec implements ImageEncoder, ImageDecoder
         return ["png"];
     }
     
-    public static function getInstance()
+    public static function getInstance(): PngCodec
     {
         if (self::$instance === null) {
             self::$instance = new PngCodec();

--- a/src/Mike42/GfxPhp/Codec/PngCodec.php
+++ b/src/Mike42/GfxPhp/Codec/PngCodec.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Codec;
 
 use Mike42\GfxPhp\RasterImage;

--- a/src/Mike42/GfxPhp/Codec/PnmCodec.php
+++ b/src/Mike42/GfxPhp/Codec/PnmCodec.php
@@ -11,7 +11,7 @@ use Exception;
 
 class PnmCodec implements ImageDecoder, ImageEncoder
 {
-    protected static $instance = null;
+    protected static ?PnmCodec $instance = null;
 
     public function identify(string $blob): string
     {
@@ -183,7 +183,7 @@ class PnmCodec implements ImageDecoder, ImageEncoder
         return ["ppm", "pgm", "pbm"];
     }
 
-    public static function getInstance()
+    public static function getInstance(): PnmCodec
     {
         if (self::$instance === null) {
             self::$instance = new PnmCodec();

--- a/src/Mike42/GfxPhp/Codec/PnmCodec.php
+++ b/src/Mike42/GfxPhp/Codec/PnmCodec.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec;
 
@@ -50,8 +51,8 @@ class PnmCodec implements ImageDecoder, ImageEncoder
         if (count($sizes) != 2 || !is_numeric($sizes[0]) || !is_numeric($sizes[1])) {
             throw new Exception("Image size is bogus, file probably corrupt.");
         }
-        $width = $sizes[0];
-        $height = $sizes[1];
+        $width = intval($sizes[0]);
+        $height = intval($sizes[1]);
         $line_end = $next_line_end;
         // Extract data and return differently based on each magic number.
         switch ($pnmMagicNumber) {

--- a/src/Mike42/GfxPhp/Codec/WbmpCodec.php
+++ b/src/Mike42/GfxPhp/Codec/WbmpCodec.php
@@ -12,7 +12,7 @@ use Mike42\GfxPhp\RasterImage;
 
 class WbmpCodec implements ImageDecoder, ImageEncoder
 {
-    protected static $instance = null;
+    protected static ?WbmpCodec $instance = null;
 
     public function identify(string $blob): string
     {
@@ -94,7 +94,7 @@ class WbmpCodec implements ImageDecoder, ImageEncoder
         return ["wbmp"];
     }
 
-    public static function getInstance()
+    public static function getInstance(): WbmpCodec
     {
         if (self::$instance === null) {
             self::$instance = new WbmpCodec();

--- a/src/Mike42/GfxPhp/Codec/WbmpCodec.php
+++ b/src/Mike42/GfxPhp/Codec/WbmpCodec.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Codec;
 

--- a/src/Mike42/GfxPhp/GrayscaleRasterImage.php
+++ b/src/Mike42/GfxPhp/GrayscaleRasterImage.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp;
 
 class GrayscaleRasterImage extends AbstractRasterImage

--- a/src/Mike42/GfxPhp/GrayscaleRasterImage.php
+++ b/src/Mike42/GfxPhp/GrayscaleRasterImage.php
@@ -5,13 +5,13 @@ namespace Mike42\GfxPhp;
 
 class GrayscaleRasterImage extends AbstractRasterImage
 {
-    protected $width;
+    protected int $width;
 
-    protected $height;
+    protected int $height;
 
-    protected $data;
+    protected array $data;
     
-    protected $maxVal;
+    protected int $maxVal;
 
     public function getWidth() : int
     {
@@ -23,7 +23,7 @@ class GrayscaleRasterImage extends AbstractRasterImage
         return $this -> height;
     }
     
-    public function setPixel(int $x, int $y, int $value)
+    public function setPixel(int $x, int $y, int $value): void
     {
         if ($x < 0 || $x >= $this -> width) {
             return;
@@ -61,7 +61,7 @@ class GrayscaleRasterImage extends AbstractRasterImage
         $this -> maxVal = $maxVal;
     }
     
-    public function getMaxVal()
+    public function getMaxVal(): int
     {
         return $this -> maxVal;
     }
@@ -83,7 +83,7 @@ class GrayscaleRasterImage extends AbstractRasterImage
         return pack("C*", ... $this -> data);
     }
     
-    public function mapColor(int $srcColor, RasterImage $destImage)
+    public function mapColor(int $srcColor, RasterImage $destImage): int
     {
         if ($destImage instanceof GrayscaleRasterImage) {
             if ($destImage -> maxVal == $this -> maxVal) {
@@ -130,7 +130,7 @@ class GrayscaleRasterImage extends AbstractRasterImage
     {
         if ($this -> maxVal > 255) {
             // Making use of how scale() uses default values to make a new canvas, which has the
-            // side-effect of creating an 8-bit image.
+            // side effect of creating an 8-bit image.
             return $this -> scale($this -> width, $this -> height) -> toIndexed();
         }
         $data = $this -> data;

--- a/src/Mike42/GfxPhp/Image.php
+++ b/src/Mike42/GfxPhp/Image.php
@@ -13,7 +13,7 @@ class Image
     const IMAGE_RGB = 3;
     const IMAGE_RGBA = 4;
 
-    protected static $codecs = null;
+    protected static ?ImageCodec $codecs = null;
     
     public static function fromFile(string $filename) : RasterImage
     {
@@ -43,7 +43,7 @@ class Image
         return $decoder -> decode($blob);
     }
     
-    public static function create(int $width, int $height, int $impl = self::IMAGE_BLACK_WHITE)
+    public static function create(int $width, int $height, int $impl = self::IMAGE_BLACK_WHITE): BlackAndWhiteRasterImage
     {
         return BlackAndWhiteRasterImage::create($width, $height);
     }
@@ -51,7 +51,7 @@ class Image
     /**
      * Call error_clear_last() if it exists. This is dependent on which PHP runtime is used.
      */
-    private static function clearLastError()
+    private static function clearLastError(): void
     {
         if (function_exists('error_clear_last')) {
             error_clear_last();
@@ -62,7 +62,7 @@ class Image
      * Retrieve the message from error_get_last() if possible. This is very useful for debugging, but it will not
      * always exist or return anything useful.
      */
-    private static function getLastErrorOrDefault(string $default)
+    private static function getLastErrorOrDefault(string $default): string
     {
         if (function_exists('error_clear_last')) {
             $e = error_get_last();

--- a/src/Mike42/GfxPhp/Image.php
+++ b/src/Mike42/GfxPhp/Image.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp;
 

--- a/src/Mike42/GfxPhp/IndexedRasterImage.php
+++ b/src/Mike42/GfxPhp/IndexedRasterImage.php
@@ -5,19 +5,19 @@ namespace Mike42\GfxPhp;
 
 class IndexedRasterImage extends AbstractRasterImage
 {
-    protected $width;
+    protected int $width;
     
-    protected $height;
+    protected int $height;
     
-    protected $data;
+    protected array $data;
     
-    protected $maxVal;
+    protected int $maxVal;
     
-    protected $palette;
+    protected array $palette;
     
-    protected $transparentColor = -1;
+    protected int $transparentColor = -1;
     
-    protected function __construct($width, $height, array $data, int $maxVal, array $palette)
+    protected function __construct(int $width, int $height, array $data, int $maxVal, array $palette)
     {
         $this -> width = $width;
         $this -> height = $height;
@@ -26,7 +26,7 @@ class IndexedRasterImage extends AbstractRasterImage
         $this -> maxVal = $maxVal;
     }
 
-    public function getPalette()
+    public function getPalette(): array
     {
         return $this -> palette;
     }
@@ -45,12 +45,12 @@ class IndexedRasterImage extends AbstractRasterImage
         return $this -> height;
     }
 
-    public function getMaxVal()
+    public function getMaxVal(): int
     {
         return $this -> maxVal;
     }
     
-    public function setPixel(int $x, int $y, int $value)
+    public function setPixel(int $x, int $y, int $value): void
     {
         if ($x < 0 || $x >= $this -> width) {
             return;
@@ -127,7 +127,7 @@ class IndexedRasterImage extends AbstractRasterImage
         return clone $this;
     }
 
-    public function indexToRgb(int $index)
+    public function indexToRgb(int $index): array
     {
         if ($index === $this -> transparentColor) {
             // White
@@ -141,7 +141,7 @@ class IndexedRasterImage extends AbstractRasterImage
         return [0, 0, 0];
     }
 
-    public function rgbToIndex(array $rgb)
+    public function rgbToIndex(array $rgb): int
     {
         $ret = array_search($rgb, $this -> palette, true);
         if ($ret !== false) {
@@ -157,12 +157,12 @@ class IndexedRasterImage extends AbstractRasterImage
         return $this -> transparentColor;
     }
 
-    public function setTransparentColor(int $color)
+    public function setTransparentColor(int $color): void
     {
         $this -> transparentColor = $color;
     }
 
-    public function setPalette(array $palette)
+    public function setPalette(array $palette): void
     {
         $palette = self::validatePalette($palette);
         // Build map of old palette colors to new ones
@@ -178,7 +178,7 @@ class IndexedRasterImage extends AbstractRasterImage
         $this -> palette = $palette;
     }
 
-    protected static function closestColorId(array $color, array $palette)
+    protected static function closestColorId(array $color, array $palette): int
     {
         $closest = 0;
         $distance = (256 ** 2) * 3;
@@ -194,7 +194,7 @@ class IndexedRasterImage extends AbstractRasterImage
         return $closest;
     }
 
-    public function setMaxVal(int $maxVal)
+    public function setMaxVal(int $maxVal): void
     {
         if ($maxVal >= count($this -> palette) - 1) {
             // No need to adjust palette
@@ -218,7 +218,7 @@ class IndexedRasterImage extends AbstractRasterImage
         throw new \Exception("Image must contain at least one color");
     }
 
-    public function allocateColor(array $color)
+    public function allocateColor(array $color): int
     {
         $idx = count($this -> palette);
         if ($idx > $this -> maxVal) {
@@ -228,7 +228,7 @@ class IndexedRasterImage extends AbstractRasterImage
         return $idx;
     }
 
-    public function deallocateColor(array $color)
+    public function deallocateColor(array $color): void
     {
         // TODO
         throw new \Exception("Not implemented");
@@ -239,7 +239,7 @@ class IndexedRasterImage extends AbstractRasterImage
         return IndexedRasterImage::create($width, $height, null, $this -> getPalette(), $this -> getMaxVal());
     }
 
-    public function mapColor(int $srcColor, RasterImage $destImage)
+    public function mapColor(int $srcColor, RasterImage $destImage): int
     {
         if ($destImage instanceof IndexedRasterImage) {
             return $srcColor;
@@ -247,7 +247,7 @@ class IndexedRasterImage extends AbstractRasterImage
         throw new \Exception("Cannot map colors");
     }
 
-    public static function create(int $width, int $height, array $data = null, array $palette = [], int $maxVal = 255)
+    public static function create(int $width, int $height, array $data = null, array $palette = [], int $maxVal = 255): IndexedRasterImage
     {
         $expectedSize = $width * $height;
         if ($data == null) {
@@ -277,7 +277,7 @@ class IndexedRasterImage extends AbstractRasterImage
         return new IndexedRasterImage($width, $height, $data, $maxVal, $palette);
     }
     
-    protected static function validatePalette($palette)
+    protected static function validatePalette($palette): array
     {
         // So that we know that we aren't missing any keys, palette should be array, not map.
         // Palette entries must be array of three values up to 255 for R, G, B.

--- a/src/Mike42/GfxPhp/IndexedRasterImage.php
+++ b/src/Mike42/GfxPhp/IndexedRasterImage.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp;
 
 class IndexedRasterImage extends AbstractRasterImage

--- a/src/Mike42/GfxPhp/PaletteGenerator.php
+++ b/src/Mike42/GfxPhp/PaletteGenerator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp;
 
 class PaletteGenerator

--- a/src/Mike42/GfxPhp/PaletteGenerator.php
+++ b/src/Mike42/GfxPhp/PaletteGenerator.php
@@ -5,7 +5,7 @@ namespace Mike42\GfxPhp;
 
 class PaletteGenerator
 {
-    public static function monochromePalette()
+    public static function monochromePalette(): array
     {
         // 256 even levels of grey
         $colorTable = [];
@@ -15,13 +15,13 @@ class PaletteGenerator
         return $colorTable;
     }
     
-    public static function blackAndWhitePalette()
+    public static function blackAndWhitePalette(): array
     {
         // 2 color levels
         return [[255, 255, 255], [0, 0, 0]];
     }
     
-    public static function colorPalette()
+    public static function colorPalette(): array
     {
         // Three bits of red, three bits of green, two bits of blue.
         $colorTable = [];
@@ -41,7 +41,7 @@ class PaletteGenerator
         return $colorTable;
     }
     
-    public static function whitePalette()
+    public static function whitePalette(): array
     {
         return [[255, 255, 255]];
     }

--- a/src/Mike42/GfxPhp/RasterImage.php
+++ b/src/Mike42/GfxPhp/RasterImage.php
@@ -2,9 +2,11 @@
 // This file is part of mike42/gfx-php, which is released under LGPL-2.1-or-later.
 // See file LICENSE or go to https://github.com/mike42/gfx-php for full license details
 
+declare(strict_types=1);
+
 /**
  * Top-level namespace for Mike42\GfxPhp, containing the classes and
- * interfaces that a provide an entry-point into the library.
+ * interfaces that provide an entry-point into the library.
  */
 namespace Mike42\GfxPhp;
 

--- a/src/Mike42/GfxPhp/RgbRasterImage.php
+++ b/src/Mike42/GfxPhp/RgbRasterImage.php
@@ -5,13 +5,13 @@ namespace Mike42\GfxPhp;
 
 class RgbRasterImage extends AbstractRasterImage
 {
-    protected $width;
+    protected int $width;
 
-    protected $height;
+    protected int $height;
 
-    protected $data;
+    protected array $data;
 
-    protected $maxVal;
+    protected int $maxVal;
 
     public function getWidth() : int
     {
@@ -31,7 +31,7 @@ class RgbRasterImage extends AbstractRasterImage
         return pack("C*", ... $this -> data);
     }
 
-    public function getMaxVal()
+    public function getMaxVal(): int
     {
         return $this -> maxVal;
     }
@@ -88,7 +88,7 @@ class RgbRasterImage extends AbstractRasterImage
         }
     }
 
-    public function mapColor(int $srcColor, RasterImage $destImage)
+    public function mapColor(int $srcColor, RasterImage $destImage): int
     {
         if ($destImage instanceof RgbRasterImage) {
             return $srcColor;

--- a/src/Mike42/GfxPhp/RgbRasterImage.php
+++ b/src/Mike42/GfxPhp/RgbRasterImage.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp;
 
 class RgbRasterImage extends AbstractRasterImage
@@ -46,22 +48,22 @@ class RgbRasterImage extends AbstractRasterImage
         return self::rgbToInt($this -> data[$byte], $this -> data[$byte + 1], $this -> data[$byte + 2], $this -> maxVal);
     }
 
-    public function indexToRgb(int $val)
+    public function indexToRgb(int $val): array
     {
         return self::intToRgb($val);
     }
     
-    public function rgbToIndex(array $val)
+    public function rgbToIndex(array $val): int
     {
         return self::rgbToInt($val[0], $val[1], $val[2]);
     }
     
-    public static function rgbToInt(int $r, int $g, int $b)
+    public static function rgbToInt(int $r, int $g, int $b): int
     {
         return ($r << 16) | ($g << 8) | $b;
     }
 
-    public static function intToRgb($in)
+    public static function intToRgb($in): array
     {
         return [
             ($in >> 16) & 0xFF,
@@ -70,7 +72,7 @@ class RgbRasterImage extends AbstractRasterImage
         ];
     }
 
-    public function setPixel(int $x, int $y, int $value)
+    public function setPixel(int $x, int $y, int $value): void
     {
         if ($x < 0 || $x >= $this -> width) {
             return;
@@ -109,17 +111,18 @@ class RgbRasterImage extends AbstractRasterImage
             $data = array_values(array_fill(0, $expectedBytes, $maxVal));
         }
         if ($maxVal > 255) {
-            array_walk($data, array('self', 'convertDepth'), [$maxVal, 255]);
+            array_walk($data, [RgbRasterImage::class, 'convertDepth'], [$maxVal, 255]);
             $maxVal = 255;
         }
         return new RgbRasterImage($width, $height, $data, $maxVal);
     }
 
-    public static function convertDepth(&$item, $key, array $data)
+    public static function convertDepth(&$item, $key, array $data): void
     {
         $maxVal = $data[0];
         $newMaxVal = $data[1];
-        $item = intdiv($item * $newMaxVal, $maxVal);
+        $bigvalue = $item * $newMaxVal;
+        $item = intdiv($bigvalue, $maxVal);
     }
 
     public function toRgb() : RgbRasterImage

--- a/src/Mike42/GfxPhp/Util/AbstractLzwDictionary.php
+++ b/src/Mike42/GfxPhp/Util/AbstractLzwDictionary.php
@@ -7,15 +7,15 @@ abstract class AbstractLzwDictionary
 {
     const MAX_SIZE = 4096;
     
-    protected $minCodeSize;
-    protected $clearCode;
-    protected $eodCode;
-    protected $size;
+    protected int $minCodeSize;
+    protected int $clearCode;
+    protected int $eodCode;
+    protected int $size;
     
     /**
      * @return number
      */
-    public function getClearCode()
+    public function getClearCode(): int
     {
         return $this->clearCode;
     }
@@ -23,7 +23,7 @@ abstract class AbstractLzwDictionary
     /**
      * @return number
      */
-    public function getEodCode()
+    public function getEodCode(): int
     {
         return $this->eodCode;
     }
@@ -34,7 +34,7 @@ abstract class AbstractLzwDictionary
         $this -> clear();
     }
     
-    public function getSize()
+    public function getSize(): int
     {
         return $this -> size;
     }

--- a/src/Mike42/GfxPhp/Util/AbstractLzwDictionary.php
+++ b/src/Mike42/GfxPhp/Util/AbstractLzwDictionary.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Util;
 
 abstract class AbstractLzwDictionary

--- a/src/Mike42/GfxPhp/Util/LzwCompression.php
+++ b/src/Mike42/GfxPhp/Util/LzwCompression.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Compression and decompression of binary data in the LZW format, as
  * used in GIF.

--- a/src/Mike42/GfxPhp/Util/LzwCompression.php
+++ b/src/Mike42/GfxPhp/Util/LzwCompression.php
@@ -19,7 +19,7 @@ namespace Mike42\GfxPhp\Util;
  */
 class LzwCompression
 {
-    public static function compress(string $inp, int $minCodeSize)
+    public static function compress(string $inp, int $minCodeSize): string
     {
         $bits = $minCodeSize + 1;
         $dict = new LzwEncodeDictionary($minCodeSize);
@@ -58,7 +58,7 @@ class LzwCompression
         return $outp -> asString();
     }
 
-    public static function decompress(string $inp, int $minCodeSize)
+    public static function decompress(string $inp, int $minCodeSize): string
     {
         $bits = $minCodeSize + 1;
         $dict = new LzwDecodeDictionary($minCodeSize);

--- a/src/Mike42/GfxPhp/Util/LzwDecodeBuffer.php
+++ b/src/Mike42/GfxPhp/Util/LzwDecodeBuffer.php
@@ -8,9 +8,9 @@ namespace Mike42\GfxPhp\Util;
  */
 class LzwDecodeBuffer
 {
-    protected $contents;
-    protected $ptr;
-    protected $len;
+    protected array $contents;
+    protected int $ptr;
+    protected int $len;
     const MASK = [0x00, 0x01, 0x03, 0x07, 0x0F, 0x1F, 0x3F, 0x7F, 0xFF];
 
     public function __construct(string $contents)
@@ -23,7 +23,7 @@ class LzwDecodeBuffer
     /**
      * @param int $readBits Number of bits to read
      */
-    public function read(int $readBits)
+    public function read(int $readBits): bool|int
     {
         $num = 0;
         $firstBit = $this -> ptr - $readBits + 1;
@@ -40,7 +40,7 @@ class LzwDecodeBuffer
         return $val;
     }
 
-    public function readBit(int $i)
+    public function readBit(int $i): int
     {
         $byte = intdiv($i, 8);
         $bit = $i % 8;

--- a/src/Mike42/GfxPhp/Util/LzwDecodeBuffer.php
+++ b/src/Mike42/GfxPhp/Util/LzwDecodeBuffer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Mike42\GfxPhp\Util;
 

--- a/src/Mike42/GfxPhp/Util/LzwDecodeDictionary.php
+++ b/src/Mike42/GfxPhp/Util/LzwDecodeDictionary.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Util;
 
 class LzwDecodeDictionary extends AbstractLzwDictionary

--- a/src/Mike42/GfxPhp/Util/LzwDecodeDictionary.php
+++ b/src/Mike42/GfxPhp/Util/LzwDecodeDictionary.php
@@ -6,9 +6,9 @@ namespace Mike42\GfxPhp\Util;
 class LzwDecodeDictionary extends AbstractLzwDictionary
 {
     
-    protected $decodeDict;
+    protected array $decodeDict;
     
-    public function clear()
+    public function clear(): void
     {
         $count = 2 << ($this -> minCodeSize - 1);
         $this -> decodeDict = range(chr(0), chr($count - 1));
@@ -19,7 +19,7 @@ class LzwDecodeDictionary extends AbstractLzwDictionary
         $this -> size = $count;
     }
     
-    public function get(int $code)
+    public function get(int $code): string
     {
         if (!$this -> contains($code)) {
             throw new \Exception("LZW decode error; was asked to retrieve code $code but dict is only 0-" . ($this -> size - 1) . ".");
@@ -27,12 +27,12 @@ class LzwDecodeDictionary extends AbstractLzwDictionary
         return $this -> decodeDict[$code];
     }
     
-    public function contains(int $code)
+    public function contains(int $code): bool
     {
         return $code < $this -> size;
     }
     
-    public function add(string $entry)
+    public function add(string $entry): void
     {
         if ($this -> size == AbstractLzwDictionary::MAX_SIZE) {
             throw new \Exception("LZW code table overflow");

--- a/src/Mike42/GfxPhp/Util/LzwEncodeBuffer.php
+++ b/src/Mike42/GfxPhp/Util/LzwEncodeBuffer.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Util;
 
 /*
@@ -6,6 +8,10 @@ namespace Mike42\GfxPhp\Util;
  */
 class LzwEncodeBuffer
 {
+    protected int $bitPos;
+    private int $bitBuffer;
+    private string $textBuffer;
+
     public function __construct()
     {
         $this -> textBuffer = "";
@@ -13,7 +19,7 @@ class LzwEncodeBuffer
         $this -> bitPos = 0;
     }
     
-    public function add(int $code, int $bits)
+    public function add(int $code, int $bits): void
     {
         $mask = [];
         $byte = 0;
@@ -42,7 +48,7 @@ class LzwEncodeBuffer
         }
     }
 
-    public function asString()
+    public function asString(): string
     {
         if ($this -> bitPos !== 0) {
             // Flush

--- a/src/Mike42/GfxPhp/Util/LzwEncodeDictionary.php
+++ b/src/Mike42/GfxPhp/Util/LzwEncodeDictionary.php
@@ -5,9 +5,9 @@ namespace Mike42\GfxPhp\Util;
 
 class LzwEncodeDictionary extends AbstractLzwDictionary
 {
-    protected $encodeDict;
+    protected array $encodeDict;
     
-    public function clear()
+    public function clear(): void
     {
         $count = 2 << ($this -> minCodeSize - 1);
         $this -> encodeDict = array_flip(range(chr(0), chr($count - 1)));
@@ -18,7 +18,7 @@ class LzwEncodeDictionary extends AbstractLzwDictionary
         $this -> size = $count;
     }
     
-    public function get(string $code)
+    public function get(string $code): int
     {
         if (!$this -> contains($code)) {
             throw new \Exception("LZW encode error; code sequence not in dictionary.");
@@ -26,12 +26,12 @@ class LzwEncodeDictionary extends AbstractLzwDictionary
         return $this -> encodeDict[$code];
     }
     
-    public function contains(string $code)
+    public function contains(string $code): bool
     {
         return isset($this -> encodeDict[$code]);
     }
     
-    public function add(string $entry)
+    public function add(string $entry): void
     {
         if ($this -> size == self::MAX_SIZE) {
             throw new \Exception("LZW code table overflow");

--- a/src/Mike42/GfxPhp/Util/LzwEncodeDictionary.php
+++ b/src/Mike42/GfxPhp/Util/LzwEncodeDictionary.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Mike42\GfxPhp\Util;
 
 class LzwEncodeDictionary extends AbstractLzwDictionary

--- a/test/benchmark/Formats/Gif/GifDecodeBench.php
+++ b/test/benchmark/Formats/Gif/GifDecodeBench.php
@@ -6,7 +6,7 @@ use Mike42\GfxPhp\Image;
  * @BeforeMethods({"init"})
  * @Revs(1000)
  */
-class GifDecodeBenchmark {
+class GifDecodeBench {
 
     private static $blob;
 

--- a/test/benchmark/Formats/Gif/LzwDecodeBench.php
+++ b/test/benchmark/Formats/Gif/LzwDecodeBench.php
@@ -6,7 +6,7 @@ use Mike42\GfxPhp\Util\LzwCompression;
  * @BeforeMethods({"init"})
  * @Revs(100)
  */
-class LzwDecodeBenchmark
+class LzwDecodeBench
 {
     private $blank;
     private $random;

--- a/test/benchmark/Formats/Gif/LzwEncodeBench.php
+++ b/test/benchmark/Formats/Gif/LzwEncodeBench.php
@@ -6,7 +6,7 @@ use Mike42\GfxPhp\Util\LzwCompression;
  * @BeforeMethods({"init"})
  * @Revs(10)
  */
-class LzwEncodeBenchmark
+class LzwEncodeBench
 {
     private $blank;
     private $random;

--- a/test/benchmark/Formats/Png/PngDecodeBench.php
+++ b/test/benchmark/Formats/Png/PngDecodeBench.php
@@ -6,7 +6,7 @@ use Mike42\GfxPhp\Image;
  * @BeforeMethods({"init"})
  * @Revs(1000)
 */
-class PngDecodeBenchmark {
+class PngDecodeBench {
 
     private static $blob;
 

--- a/test/benchmark/Operations/ConvertRasterImageBench.php
+++ b/test/benchmark/Operations/ConvertRasterImageBench.php
@@ -6,7 +6,7 @@ use Mike42\GfxPhp\Image;
  * @BeforeMethods({"init"})
  * @Revs(1000)
  */
-class ConvertRasterImageBenchmark
+class ConvertRasterImageBench
 {
     private static $bw100;
     private static $gray100;

--- a/test/benchmark/Operations/ScaleDownBench.php
+++ b/test/benchmark/Operations/ScaleDownBench.php
@@ -9,7 +9,7 @@ use Mike42\GfxPhp\RgbRasterImage;
  * @BeforeMethods({"init"})
  * @Revs(10000)
  */
-class ScaleDownBenchmark
+class ScaleDownBench
 {
     private static $bw100;
     private static $rgb100;

--- a/test/benchmark/Operations/ScaleUpBench.php
+++ b/test/benchmark/Operations/ScaleUpBench.php
@@ -9,7 +9,7 @@ use Mike42\GfxPhp\RgbRasterImage;
  * @BeforeMethods({"init"})
  * @Revs(10)
  */
-class ScaleUpBenchmark
+class ScaleUpBench
 {
     private static $bw10;
     private static $rgb10;


### PR DESCRIPTION
- Updates supported version range to 8.1 or higher, excluding now-unsupported PHP versions.
- Selects latest stable version of all development dependencies: PHPUnit, PHPCS, PHPBench.
- Corrects issues which were raising deprecation warnings on recent PHP versions
- Making further use of [type declarations](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations) - field types and void return values were not available over the previously supported version range.

Closes #56