### PR TITLE
Follow-up fixes

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,0 @@
-service_name: travis-ci
-coverage_clover: build/logs/clover.xml
-json_path: build/logs/coveralls-upload.json
-

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .github/ export-ignore
-.coveralls.yml export-ignore
 docs/ export-ignore
 example/ export-ignore
 phpbench.json.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,12 @@
 * text=auto
 
 .gitattributes export-ignore
+.gitignore export-ignore
 .github/ export-ignore
+.coveralls.yml export-ignore
 docs/ export-ignore
 example/ export-ignore
 phpbench.json.dist export-ignore
 phpunit.xml export-ignore
 test/ export-ignore
+composer.lock export-ignore

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/mike42/gfx-php/ci.yml?branch=main&style=flat-square)](https://github.com/mike42/gfx-php/actions/workflows/ci.yml)
 [![Packagist Version](https://img.shields.io/packagist/v/mike42/gfx-php?style=flat-square&color=007ec6)](https://packagist.org/packages/mike42/gfx-php)
 [![Packagist Downloads](https://img.shields.io/packagist/dt/mike42/gfx-php?style=flat-square)](https://packagist.org/packages/mike42/gfx-php)
-[![Packagist License](https://img.shields.io/packagist/l/mike42/gfx-php?style=flat-square&color=007ec6)](https://packagist.org/packages/mike42/gfx-php)
+[![Packagist License](https://img.shields.io/packagist/l/mike42/gfx-php?style=flat-square&color=007ec6)](https://github.com/mike42/gfx-php/blob/main/LICENSE)
 
 This library implements input, output and processing of raster images in pure PHP, so that image
 processing extensions (Gd, Imagick) are not required.


### PR DESCRIPTION
Updating the README so that the license links to `LICENSE` in the repo, also removing some files from distribution via `.gitattributes` (thanks @erikn69).

No intention to tag a release for this immediately.
